### PR TITLE
Support multiple nodes on replaceWith

### DIFF
--- a/src/__tests__/node.js
+++ b/src/__tests__/node.js
@@ -16,8 +16,9 @@ test('node#replaceWith', (t) => {
     t.plan(1);
     let out = parse('[href="test"]', (selectors) => {
         let attr = selectors.first.first;
+        let id = parser.id({value: 'test'});
         let className = parser.className({value: 'test'});
-        attr.replaceWith(className);
+        attr.replaceWith(id, className);
     });
-    t.equal(out, '.test');
+    t.equal(out, '#test.test');
 });

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -40,9 +40,13 @@ export default class {
         return this;
     }
 
-    replaceWith (node) {
-        this.parent.insertBefore(this, node);
-        this.removeSelf();
+    replaceWith () {
+        if (this.parent) {
+            for (let index in arguments) {
+                this.parent.insertBefore(this, arguments[index]);
+            }
+            this.removeSelf();
+        }
         return this;
     }
 


### PR DESCRIPTION
The DOM4 [replaceWith](https://dom.spec.whatwg.org/#dom-childnode-replacewithnodes) method accepts multiple elements. Feature parity would be helpful in **postcss** and **postcss-selector-parser**.

- Updates replaceWith method
- Updates replaceWith test

Examples:

```js
/* without replaceWith support for multiple nodes */

let id = parser.id({ value: 'id' });
let className = parser.className({ value: 'class' });

if (node.parent) {
    node.parent.insertBefore(node, id);
    node.parent.insertBefore(node, className);

    node.removeSelf();
}
```

```js
/* with replaceWith support for multiple nodes */

let id = parser.id({ value: 'id' });
let className = parser.className({ value: 'class' });

node.replaceWith(id, className);
```