### PR TITLE
fix error when parsing invalid pseudo class

### DIFF
--- a/src/__tests__/exceptions.js
+++ b/src/__tests__/exceptions.js
@@ -3,6 +3,7 @@
 import {throws} from './util/helpers';
 
 throws('unclosed pseudo element', 'button::');
+throws('unclosed pseudo class', 'a:');
 throws('bad pseudo element', 'button::"after"');
 throws('unclosed attribute selector', '[name="james"][href');
 throws('missing closing parenthesis in pseudo', ':not([attr="test"]:not([attr="test"])');

--- a/src/parser.js
+++ b/src/parser.js
@@ -167,9 +167,12 @@ export default class Parser {
 
     pseudo () {
         let pseudoStr = '';
-        while (this.currToken[0] === ':') {
+        while (this.currToken && this.currToken[0] === ':') {
             pseudoStr += this.currToken[1];
             this.position ++;
+        }
+        if (!this.currToken) {
+            return this.error('Expected pseudo-class or pseudo-element');
         }
         if (this.currToken[0] === 'word') {
             let pseudo;


### PR DESCRIPTION
Hello, 

When parsing an invalid pseudo class I would get an exception show below.  I have made a change to throw a more friendly and expected error message 'Expected pseudo-class or pseudo-element'.  I looked at updating your test helper to allow to check for a proper exception message but didn't quite figure it out so currently the tests are hiding the issue by not asserting on the type of error.

```
:\inetpub\wwwroot\git\postcss-selector-parser\dist\parser.js:250
            if (this.currToken[0] === 'word') {
                              ^
TypeError: Cannot read property '0' of undefined
    at Parser.pseudo (C:\inetpub\wwwroot\git\postcss-selector-parser\dist\parser.js:250:31)
    at Parser.parse (C:\inetpub\wwwroot\git\postcss-selector-parser\dist\parser.js:372:26)
    at Parser.loop (C:\inetpub\wwwroot\git\postcss-selector-parser\dist\parser.js:347:22)
    at new Parser (C:\inetpub\wwwroot\git\postcss-selector-parser\dist\parser.js:87:21)
    at Processor.process (C:\inetpub\wwwroot\git\postcss-selector-parser\dist\processor.js:36:25)
    at Object.<anonymous> (C:\inetpub\wwwroot\postcss-selector-parser-test\index.js:9:37)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```

