### PR TITLE
Add index to token for accurate sourceIndex

### DIFF
--- a/src/__tests__/sourceIndex.js
+++ b/src/__tests__/sourceIndex.js
@@ -182,3 +182,82 @@ test('multiple pseudos', 'h1:not(.food)::before, a:first-child', (t, tree) => {
     t.equal(tree.nodes[1].nodes[1].source.end.column, 36);
     t.equal(tree.nodes[1].nodes[1].sourceIndex, 24);
 });
+
+test('multiple id selectors on different lines', '#one,\n#two', (t, tree) => {
+    t.plan(8);
+
+    t.equal(tree.nodes[0].nodes[0].source.start.line, 1);
+    t.equal(tree.nodes[0].nodes[0].source.start.column, 1);
+    t.equal(tree.nodes[0].nodes[0].source.end.column, 4);
+    t.equal(tree.nodes[0].nodes[0].sourceIndex, 0);
+
+    t.equal(tree.nodes[1].nodes[0].source.start.line, 2);
+    t.equal(tree.nodes[1].nodes[0].source.start.column, 1);
+    t.equal(tree.nodes[1].nodes[0].source.end.column, 4);
+    t.equal(tree.nodes[1].nodes[0].sourceIndex, 6);
+});
+
+test('multiple id selectors on different CRLF lines', '#one,\r\n#two,\r\n#three', (t, tree) => {
+    t.plan(12);
+
+    t.equal(tree.nodes[0].nodes[0].source.start.line, 1, '#one start line');
+    t.equal(tree.nodes[0].nodes[0].source.start.column, 1, '#one start column');
+    t.equal(tree.nodes[0].nodes[0].source.end.column, 4, '#one end column');
+    t.equal(tree.nodes[0].nodes[0].sourceIndex, 0, '#one sourceIndex');
+
+    t.equal(tree.nodes[1].nodes[0].source.start.line, 2, '#two start line');
+    t.equal(tree.nodes[1].nodes[0].source.start.column, 1, '#two start column');
+    t.equal(tree.nodes[1].nodes[0].source.end.column, 4, '#two end column');
+    t.equal(tree.nodes[1].nodes[0].sourceIndex, 7, '#two sourceIndex');
+
+    t.equal(tree.nodes[2].nodes[0].source.start.line, 3, '#three start line');
+    t.equal(tree.nodes[2].nodes[0].source.start.column, 1, '#three start column');
+    t.equal(tree.nodes[2].nodes[0].source.end.column, 6, '#three end column');
+    t.equal(tree.nodes[2].nodes[0].sourceIndex, 14, '#three sourceIndex');
+});
+
+test('id, tag, pseudo, and class selectors on different lines with indentation', '\t#one,\n\th1:after,\n\t\t.two', (t, tree) => {
+    t.plan(16);
+
+    t.equal(tree.nodes[0].nodes[0].source.start.line, 1, '#one start line');
+    t.equal(tree.nodes[0].nodes[0].source.start.column, 2, '#one start column');
+    t.equal(tree.nodes[0].nodes[0].source.end.column, 5, '#one end column');
+    t.equal(tree.nodes[0].nodes[0].sourceIndex, 1, '#one sourceIndex');
+
+    t.equal(tree.nodes[1].nodes[0].source.start.line, 2, 'h1 start line');
+    t.equal(tree.nodes[1].nodes[0].source.start.column, 2, 'h1 start column');
+    t.equal(tree.nodes[1].nodes[0].source.end.column, 3, 'h1 end column');
+    t.equal(tree.nodes[1].nodes[0].sourceIndex, 8, 'h1 sourceIndex');
+
+    t.equal(tree.nodes[1].nodes[1].source.start.line, 2, ':after start line');
+    t.equal(tree.nodes[1].nodes[1].source.start.column, 4, ':after start column');
+    t.equal(tree.nodes[1].nodes[1].source.end.column, 9, ':after end column');
+    t.equal(tree.nodes[1].nodes[1].sourceIndex, 10, ':after sourceIndex');
+
+    t.equal(tree.nodes[2].nodes[0].source.start.line, 3, '.two start line');
+    t.equal(tree.nodes[2].nodes[0].source.start.column, 3, '.two start column');
+    t.equal(tree.nodes[2].nodes[0].source.end.column, 6, '.two end column');
+    t.equal(tree.nodes[2].nodes[0].sourceIndex, 20, '.two sourceIndex');
+});
+
+test('pseudo with arguments spanning multiple lines', 'h1:not(\n\t.one,\n\t.two\n)', (t, tree) => {
+    t.plan(15);
+
+    t.equal(tree.nodes[0].nodes[1].source.start.line, 1, ':not start line');
+    t.equal(tree.nodes[0].nodes[1].source.start.column, 3, ':not start column');
+    t.equal(tree.nodes[0].nodes[1].source.end.line, 4, ':not end line');
+    t.equal(tree.nodes[0].nodes[1].source.end.column, 1, ':not end column');
+    t.equal(tree.nodes[0].nodes[1].sourceIndex, 2, ':not sourceIndex');
+
+    t.equal(tree.nodes[0].nodes[1].nodes[0].nodes[0].source.start.line, 2, '.one start line');
+    t.equal(tree.nodes[0].nodes[1].nodes[0].nodes[0].source.start.column, 2, '.one start column');
+    t.equal(tree.nodes[0].nodes[1].nodes[0].nodes[0].source.end.line, 2, '.one end line');
+    t.equal(tree.nodes[0].nodes[1].nodes[0].nodes[0].source.end.column, 5, '.one end column');
+    t.equal(tree.nodes[0].nodes[1].nodes[0].nodes[0].sourceIndex, 9, '.one sourceIndex');
+
+    t.equal(tree.nodes[0].nodes[1].nodes[1].nodes[0].source.start.line, 3, '.two start line');
+    t.equal(tree.nodes[0].nodes[1].nodes[1].nodes[0].source.start.column, 2, '.two start column');
+    t.equal(tree.nodes[0].nodes[1].nodes[1].nodes[0].source.end.line, 3, '.two end line');
+    t.equal(tree.nodes[0].nodes[1].nodes[1].nodes[0].source.end.column, 5, '.two end column');
+    t.equal(tree.nodes[0].nodes[1].nodes[1].nodes[0].sourceIndex, 16, '.two sourceIndex');
+});

--- a/src/parser.js
+++ b/src/parser.js
@@ -59,7 +59,8 @@ export default class Parser {
                     line: this.currToken[2],
                     column: this.currToken[3]
                 }
-            }
+            },
+            sourceIndex: startingToken[4]
         };
         if (namespace.length > 1) {
             if (namespace[0] === '') { namespace[0] = true; }
@@ -97,7 +98,8 @@ export default class Parser {
                     line: this.currToken[2],
                     column: this.currToken[3]
                 }
-            }
+            },
+            sourceIndex: this.currToken[4]
         });
         while ( this.position < this.tokens.length &&
                 this.currToken[0] === 'space' ||
@@ -140,7 +142,8 @@ export default class Parser {
                     line: this.currToken[4],
                     column: this.currToken[5]
                 }
-            }
+            },
+            sourceIndex: this.currToken[6]
         });
         this.newNode(comment);
         this.position++;
@@ -223,7 +226,8 @@ export default class Parser {
                             line: this.currToken[4],
                             column: this.currToken[5]
                         }
-                    }
+                    },
+                    sourceIndex: startingToken[4]
                 });
                 this.newNode(pseudo);
                 if (length > 1 && this.nextToken && this.nextToken[0] === '(') {
@@ -266,7 +270,8 @@ export default class Parser {
                     line: this.currToken[2],
                     column: this.currToken[3]
                 }
-            }
+            },
+            sourceIndex: this.currToken[4]
         }), namespace);
         this.position ++;
     }
@@ -309,7 +314,8 @@ export default class Parser {
                             line: this.currToken[4],
                             column: this.currToken[3] + (index - 1)
                         }
-                    }
+                    },
+                    sourceIndex: this.currToken[6] + indices[i]
                 });
             } else if (~hasId.indexOf(ind)) {
                 node = new ID({
@@ -323,7 +329,8 @@ export default class Parser {
                             line: this.currToken[4],
                             column: this.currToken[3] + (index - 1)
                         }
-                    }
+                    },
+                    sourceIndex: this.currToken[6] + indices[i]
                 });
             } else {
                 node = new Tag({
@@ -337,7 +344,8 @@ export default class Parser {
                             line: this.currToken[4],
                             column: this.currToken[3] + (index - 1)
                         }
-                    }
+                    },
+                    sourceIndex: this.currToken[6] + indices[i]
                 });
             }
             this.newNode(node, namespace);

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -73,8 +73,4 @@ export default class {
             this.spaces.after
         ].join('');
     }
-
-    get sourceIndex () {
-        return this.source.start.column - 1;
-    }
 }

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -42,7 +42,7 @@ export default function tokenize(input) {
             css += end;
             next = css.length - 1;
         } else {
-            throw input.error('Unclosed ' + what, line, pos - offset);
+            throw input.error('Unclosed ' + what, line, pos - offset, pos);
         }
     };
 
@@ -74,7 +74,7 @@ export default function tokenize(input) {
                           code === cr      ||
                           code === feed );
 
-                tokens.push(['space', css.slice(pos, next), line, pos - offset]);
+                tokens.push(['space', css.slice(pos, next), line, pos - offset, pos]);
                 pos = next - 1;
                 break;
 
@@ -90,40 +90,40 @@ export default function tokenize(input) {
                           code === gt    ||
                           code === tilde ||
                           code === pipe );
-                tokens.push(['combinator', css.slice(pos, next), line, pos - offset]);
+                tokens.push(['combinator', css.slice(pos, next), line, pos - offset, pos]);
                 pos = next - 1;
                 break;
 
             case asterisk:
-                tokens.push(['*', '*', line, pos - offset]);
+                tokens.push(['*', '*', line, pos - offset, pos]);
                 break;
 
             case comma:
-                tokens.push([',', ',', line, pos - offset]);
+                tokens.push([',', ',', line, pos - offset, pos]);
                 break;
 
             case openSq:
-                tokens.push(['[', '[', line, pos - offset]);
+                tokens.push(['[', '[', line, pos - offset, pos]);
                 break;
 
             case closeSq:
-                tokens.push([']', ']', line, pos - offset]);
+                tokens.push([']', ']', line, pos - offset, pos]);
                 break;
 
             case colon:
-                tokens.push([':', ':', line, pos - offset]);
+                tokens.push([':', ':', line, pos - offset, pos]);
                 break;
 
             case semicolon:
-                tokens.push([';', ';', line, pos - offset]);
+                tokens.push([';', ';', line, pos - offset, pos]);
                 break;
 
             case openBracket:
-                tokens.push(['(', '(', line, pos - offset]);
+                tokens.push(['(', '(', line, pos - offset, pos]);
                 break;
 
             case closeBracket:
-                tokens.push([')', ')', line, pos - offset]);
+                tokens.push([')', ')', line, pos - offset, pos]);
                 break;
 
             case singleQuote:
@@ -143,7 +143,8 @@ export default function tokenize(input) {
 
                 tokens.push(['string', css.slice(pos, next + 1),
                     line, pos  - offset,
-                    line, next - offset
+                    line, next - offset,
+                    pos
                 ]);
                 pos = next;
                 break;
@@ -158,7 +159,8 @@ export default function tokenize(input) {
                 }
                 tokens.push(['at-word', css.slice(pos, next + 1),
                     line, pos  - offset,
-                    line, next - offset
+                    line, next - offset,
+                    pos
                 ]);
                 pos = next;
                 break;
@@ -181,7 +183,8 @@ export default function tokenize(input) {
                 }
                 tokens.push(['word', css.slice(pos, next + 1),
                     line, pos  - offset,
-                    line, next - offset
+                    line, next - offset,
+                    pos
                 ]);
                 pos = next;
                 break;
@@ -205,7 +208,8 @@ export default function tokenize(input) {
 
                     tokens.push(['comment', content,
                         line,     pos  - offset,
-                        nextLine, next - nextOffset
+                        nextLine, next - nextOffset,
+                        pos
                     ]);
 
                     offset = nextOffset;
@@ -223,7 +227,8 @@ export default function tokenize(input) {
 
                     tokens.push(['word', css.slice(pos, next + 1),
                         line, pos  - offset,
-                        line, next - offset
+                        line, next - offset,
+                        pos
                     ]);
                     pos = next;
                 }


### PR DESCRIPTION
This one is more intrusive then the others. Definitely curious if you think there's a better way.

What I did was add another data point to each token, representing its sourceIndex. For both token that only have line/column and those that have start and end line/columns, I tacked it onto the end of the token array, so it wouldn't break any existing stuff.

With that info in the token, complex multiline `sourceIndex`es kind of took care of themselves. I wrote a number of tests to add some confidence that it's working as expected.

What do you think?

If you accept this one, can you think of any other source line/column/sourceIndex work that needs to be done?