### PR TITLE
Update flatten from v0.0.1 to v1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run test-unformatted | faucet"
   },
   "dependencies": {
-    "flatten": "0.0.1",
+    "flatten": "^1.0.2",
     "indexes-of": "^1.0.1",
     "uniq": "^1.0.1"
   },


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
