### PR TITLE
Adds quoted and raw.unquoted properties to attribute nodes

### DIFF
--- a/API.md
+++ b/API.md
@@ -548,3 +548,29 @@ A pseudo selector extends a container node; if it has any parameters of its
 own (such as `h1:not(h2, h3)`), they will be its children. Note that the pseudo
 `value` will always contain the colons preceding the pseudo identifier. This
 is so that both `:before` and `::before` are properly represented in the AST.
+
+## Attribute nodes
+
+### `attribute.quoted`
+
+Returns `true` if the attribute's value is wrapped in quotation marks, false if it is not.
+Remains `undefined` if there is no attribute value.
+
+```css
+[href=foo] /* false */
+[href='foo'] /* true */
+[href="foo"] /* true */
+[href] /* undefined */
+```
+
+### `attribute.raw.unquoted`
+
+Returns the unquoted content of the attribute's value.
+Remains `undefined` if there is no attribute value.
+
+```css
+[href=foo] /* foo */
+[href='foo'] /* foo */
+[href="foo"] /* foo */
+[href] /* undefined */
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and;
 
 * Fixes parsing of attribute selectors with equals signs in them
   (e.g. `[data-attr="foo=bar"]`) (thanks to @montmanu).
+* Adds `quoted` and `raw.unquoted` properties to attribute nodes.
 
 # 1.3.3
 

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -3,6 +3,7 @@ import {test} from './util/helpers';
 test('attribute selector', '[href]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');
     t.deepEqual(tree.nodes[0].nodes[0].type, 'attribute');
+    t.falsy(tree.nodes[0].nodes[0].quoted);
 });
 
 test('multiple attribute selectors', '[href][class][name]', (t, tree) => {
@@ -15,16 +16,22 @@ test('attribute selector with a value', '[name=james]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'name');
     t.deepEqual(tree.nodes[0].nodes[0].operator, '=');
     t.deepEqual(tree.nodes[0].nodes[0].value, 'james');
+    t.falsy(tree.nodes[0].nodes[0].quoted);
+    t.deepEqual(tree.nodes[0].nodes[0].raw.unquoted, 'james');
 });
 
 test('attribute selector with quoted value', '[name="james"]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'name');
     t.deepEqual(tree.nodes[0].nodes[0].operator, '=');
     t.deepEqual(tree.nodes[0].nodes[0].value, '"james"');
+    t.truthy(tree.nodes[0].nodes[0].quoted);
+    t.deepEqual(tree.nodes[0].nodes[0].raw.unquoted, 'james');
 });
 
 test('attribute selector with escaped quote', '[title="Something \\"weird\\""]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, '"Something \\"weird\\""');
+    t.truthy(tree.nodes[0].nodes[0].quoted);
+    t.deepEqual(tree.nodes[0].nodes[0].raw.unquoted, 'Something \\"weird\\"');
 });
 
 test('multiple attribute selectors + combinator', '[href][class][name] h1 > h2', (t, tree) => {
@@ -50,12 +57,19 @@ test('attribute selector with quoted value & combinator', '[name="james"] > h1',
 test('multiple quoted attribute selectors', '[href*="test.com"][rel="external"][id][class~="test"] > [name]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');
     t.deepEqual(tree.nodes[0].nodes[0].value, '"test.com"');
+    t.truthy(tree.nodes[0].nodes[0].quoted);
+    t.deepEqual(tree.nodes[0].nodes[0].raw.unquoted, 'test.com');
     t.deepEqual(tree.nodes[0].nodes[1].attribute, 'rel');
     t.deepEqual(tree.nodes[0].nodes[1].value, '"external"');
+    t.truthy(tree.nodes[0].nodes[1].quoted);
+    t.deepEqual(tree.nodes[0].nodes[1].raw.unquoted, 'external');
     t.deepEqual(tree.nodes[0].nodes[2].attribute, 'id');
     t.falsy(tree.nodes[0].nodes[2].value, 'should not have a value');
+    t.falsy(tree.nodes[0].nodes[2].quoted);
     t.deepEqual(tree.nodes[0].nodes[3].attribute, 'class');
     t.deepEqual(tree.nodes[0].nodes[3].value, '"test"');
+    t.truthy(tree.nodes[0].nodes[3].quoted);
+    t.deepEqual(tree.nodes[0].nodes[3].raw.unquoted, 'test');
     t.deepEqual(tree.nodes[0].nodes[4].value, '>');
     t.deepEqual(tree.nodes[0].nodes[5].attribute, 'name');
     t.falsy(tree.nodes[0].nodes[5].value, 'should not have a value');
@@ -72,6 +86,8 @@ test('attribute selector with quoted value containing "="', '[data-weird-attr="S
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'data-weird-attr');
     t.deepEqual(tree.nodes[0].nodes[0].operator, '=');
     t.deepEqual(tree.nodes[0].nodes[0].value, '"Something=weird"');
+    t.truthy(tree.nodes[0].nodes[0].quoted);
+    t.deepEqual(tree.nodes[0].nodes[0].raw.unquoted, 'Something=weird');
 });
 
 let selector = '[data-weird-attr*="Something=weird"],' +

--- a/src/parser.js
+++ b/src/parser.js
@@ -80,6 +80,8 @@ export default class Parser {
                 attr.insensitive = true;
                 attr.raw.insensitive = insensitive[1];
             }
+            attr.quoted = attr.value[0] === '\'' || attr.value[0] === '"';
+            attr.raw.unquoted = (attr.quoted) ? attr.value.slice(1, -1) : attr.value;
         }
         this.newNode(attr);
         this.position++;


### PR DESCRIPTION
Closes #50.

Does this look like what you were imagining, @ben-eb?

If this is accepted, the only other issue holding up 2.0 is a simple find-replace, right?