### PR TITLE
Use and export type constants for selectors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,4 +64,19 @@ parser.universal = function (opts) {
     return new Universal(opts);
 };
 
+export {
+    TAG,
+    STRING,
+    SELECTOR,
+    ROOT,
+    PSEUDO,
+    NESTING,
+    ID,
+    COMMENT,
+    COMBINATOR,
+    CLASS,
+    ATTRIBUTE,
+    UNIVERSAL
+} from './selectors/types';
+
 export default parser;

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,8 @@ import flatten from 'flatten';
 import indexesOf from 'indexes-of';
 import uniq from 'uniq';
 
+import * as types from './selectors/types';
+
 export default class Parser {
     constructor (input) {
         this.input = input;
@@ -199,7 +201,7 @@ export default class Parser {
 
     parentheses () {
         let last = this.current.last;
-        if (last && last.type === 'pseudo') {
+        if (last && last.type === types.PSEUDO) {
             let selector = new Selector();
             let cache = this.current;
             last.append(selector);

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -1,9 +1,10 @@
 import Namespace from './namespace';
+import {ATTRIBUTE} from './types';
 
 export default class Attribute extends Namespace {
     constructor (opts) {
         super(opts);
-        this.type = 'attribute';
+        this.type = ATTRIBUTE;
         this.raws = {};
     }
 
@@ -15,7 +16,7 @@ export default class Attribute extends Namespace {
             this.attribute
         ];
 
-        if (this.operator) { 
+        if (this.operator) {
             selector.push(this.operator);
         }
         if (this.value) {

--- a/src/selectors/className.js
+++ b/src/selectors/className.js
@@ -1,9 +1,10 @@
 import Namespace from './namespace';
+import {CLASS} from './types';
 
 export default class ClassName extends Namespace {
     constructor (opts) {
         super(opts);
-        this.type = 'class';
+        this.type = CLASS;
     }
 
     toString () {

--- a/src/selectors/combinator.js
+++ b/src/selectors/combinator.js
@@ -1,8 +1,9 @@
 import Node from './node';
+import {COMBINATOR} from './types';
 
 export default class Combinator extends Node {
     constructor (opts) {
         super(opts);
-        this.type = 'combinator';
+        this.type = COMBINATOR;
     }
 }

--- a/src/selectors/comment.js
+++ b/src/selectors/comment.js
@@ -1,8 +1,9 @@
 import Node from './node';
+import {COMMENT} from './types';
 
 export default class Comment extends Node {
     constructor (opts) {
         super(opts);
-        this.type = 'comment';
+        this.type = COMMENT;
     }
 }

--- a/src/selectors/container.js
+++ b/src/selectors/container.js
@@ -1,4 +1,5 @@
 import Node from './node';
+import * as types from './types';
 
 export default class Container extends Node {
     constructor (opts) {
@@ -151,7 +152,7 @@ export default class Container extends Node {
 
     walkAttributes (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'attribute') {
+            if (selector.type === types.ATTRIBUTE) {
                 return callback.call(this, selector);
             }
         });
@@ -159,7 +160,7 @@ export default class Container extends Node {
 
     walkClasses (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'class') {
+            if (selector.type === types.CLASS) {
                 return callback.call(this, selector);
             }
         });
@@ -167,7 +168,7 @@ export default class Container extends Node {
 
     walkCombinators (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'combinator') {
+            if (selector.type === types.COMBINATOR) {
                 return callback.call(this, selector);
             }
         });
@@ -175,7 +176,7 @@ export default class Container extends Node {
 
     walkComments (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'comment') {
+            if (selector.type === types.COMMENT) {
                 return callback.call(this, selector);
             }
         });
@@ -183,15 +184,15 @@ export default class Container extends Node {
 
     walkIds (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'id') {
+            if (selector.type === types.ID) {
                 return callback.call(this, selector);
             }
         });
     }
-    
+
     walkNesting (callback) {
         return this.walk(selector => {
-            if (selector.type === 'nesting') {
+            if (selector.type === types.NESTING) {
                 return callback.call(this, selector);
             }
         });
@@ -199,7 +200,7 @@ export default class Container extends Node {
 
     walkPseudos (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'pseudo') {
+            if (selector.type === types.PSEUDO) {
                 return callback.call(this, selector);
             }
         });
@@ -207,7 +208,7 @@ export default class Container extends Node {
 
     walkTags (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'tag') {
+            if (selector.type === types.TAG) {
                 return callback.call(this, selector);
             }
         });
@@ -215,7 +216,7 @@ export default class Container extends Node {
 
     walkUniversals (callback) {
         return this.walk((selector) => {
-            if (selector.type === 'universal') {
+            if (selector.type === types.UNIVERSAL) {
                 return callback.call(this, selector);
             }
         });

--- a/src/selectors/id.js
+++ b/src/selectors/id.js
@@ -1,9 +1,10 @@
 import Namespace from './namespace';
+import {ID as IDType} from './types';
 
 export default class ID extends Namespace {
     constructor (opts) {
         super(opts);
-        this.type = 'id';
+        this.type = IDType;
     }
 
     toString () {

--- a/src/selectors/nesting.js
+++ b/src/selectors/nesting.js
@@ -1,9 +1,10 @@
 import Node from './node';
+import {NESTING} from './types';
 
 export default class Nesting extends Node {
     constructor (opts) {
         super(opts);
-        this.type = 'nesting';
+        this.type = NESTING;
         this.value = '&';
     }
 }

--- a/src/selectors/pseudo.js
+++ b/src/selectors/pseudo.js
@@ -1,9 +1,10 @@
 import Container from './container';
+import {PSEUDO} from './types';
 
 export default class Pseudo extends Container {
     constructor (opts) {
         super(opts);
-        this.type = 'pseudo';
+        this.type = PSEUDO;
     }
 
     toString () {

--- a/src/selectors/root.js
+++ b/src/selectors/root.js
@@ -1,9 +1,10 @@
 import Container from './container';
+import {ROOT} from './types';
 
 export default class Root extends Container {
     constructor (opts) {
         super(opts);
-        this.type = 'root';
+        this.type = ROOT;
     }
 
     toString () {

--- a/src/selectors/selector.js
+++ b/src/selectors/selector.js
@@ -1,8 +1,9 @@
 import Container from './container';
+import {SELECTOR} from './types';
 
 export default class Selector extends Container {
     constructor (opts) {
         super(opts);
-        this.type = 'selector';
+        this.type = SELECTOR;
     }
 }

--- a/src/selectors/string.js
+++ b/src/selectors/string.js
@@ -1,8 +1,9 @@
 import Node from './node';
+import {STRING} from './types';
 
 export default class String extends Node {
     constructor (opts) {
         super(opts);
-        this.type = 'string';
+        this.type = STRING;
     }
 }

--- a/src/selectors/tag.js
+++ b/src/selectors/tag.js
@@ -1,8 +1,9 @@
 import Namespace from './namespace';
+import {TAG} from './types';
 
 export default class Tag extends Namespace {
     constructor (opts) {
         super(opts);
-        this.type = 'tag';
+        this.type = TAG;
     }
 }

--- a/src/selectors/types.js
+++ b/src/selectors/types.js
@@ -1,0 +1,12 @@
+export const TAG = 'tag';
+export const STRING = 'string';
+export const SELECTOR = 'selector';
+export const ROOT = 'root';
+export const PSEUDO = 'pseudo';
+export const NESTING = 'nesting';
+export const ID = 'id';
+export const COMMENT = 'comment';
+export const COMBINATOR = 'combinator';
+export const CLASS = 'class';
+export const ATTRIBUTE = 'attribute';
+export const UNIVERSAL = 'universal';

--- a/src/selectors/universal.js
+++ b/src/selectors/universal.js
@@ -1,9 +1,10 @@
 import Namespace from './namespace';
+import {UNIVERSAL} from './types';
 
 export default class Universal extends Namespace {
     constructor (opts) {
         super(opts);
-        this.type = 'universal';
+        this.type = UNIVERSAL;
         this.value = '*';
     }
 }


### PR DESCRIPTION
Hey there!

We are just about to integrate this package with enzyme, a testing utility for React. you can see the PR here: https://github.com/airbnb/enzyme/pull/458

It would be useful if we could import the selector types so we cleanly parse the returned AST for our use case.

I've replaced all the string literals I found for `this.type` with constants of the same value.