### PR TITLE
Better handling `quoted` inside attribute selector.

### DIFF
--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -218,6 +218,8 @@ test('spaces in attribute selectors', 'h1[  href  *=  "test"  ]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[1].attribute, '  href  ');
     t.deepEqual(tree.nodes[0].nodes[1].operator, '*=');
     t.deepEqual(tree.nodes[0].nodes[1].value, '  "test"  ');
+    t.truthy(tree.nodes[0].nodes[1].quoted);
+    t.deepEqual(tree.nodes[0].nodes[1].raws.unquoted, 'test');
 });
 
 test('insensitive attribute selector 1', '[href="test" i]', (t, tree) => {

--- a/src/parser.js
+++ b/src/parser.js
@@ -82,8 +82,9 @@ export default class Parser {
                 attr.insensitive = true;
                 attr.raws.insensitive = insensitive[1];
             }
-            attr.quoted = attr.value[0] === '\'' || attr.value[0] === '"';
-            attr.raws.unquoted = (attr.quoted) ? attr.value.slice(1, -1) : attr.value;
+            let trimmedValue = attr.value.trim();
+            attr.quoted = trimmedValue[0] === '\'' || trimmedValue[0] === '"';
+            attr.raws.unquoted = (attr.quoted) ? trimmedValue.slice(1, -1) : trimmedValue;
         }
         this.newNode(attr);
         this.position++;


### PR DESCRIPTION
https://github.com/postcss/postcss-selector-parser/issues/71
Maybe we should rewrite `attribute` selector parsing, inside `attribute` and `value` have trimmed value. And add `raws.spaceBeforeAttribute`, `raws.spaceAfterAttribute`, `raws.spaceBeforeOperator`, `raws.spaceAfterOperator`, `raws.spaceBeforeValue` and `raws.spaceAfterValue`. If you say yes on this i will help with this.