### PR TITLE
container#insertBefore/After correctly adjust indexes

### DIFF
--- a/src/__tests__/container.js
+++ b/src/__tests__/container.js
@@ -14,6 +14,22 @@ test('container#each', (t) => {
     t.deepEqual(str, 'h1h2');
 });
 
+test('container#each (safe iteration)', (t) => {
+    let out = parse('.x, .y', (selectors) => {
+        selectors.each((selector) => {
+            selector.parent.insertBefore(
+                selector,
+                parser.className({value : 'b'})
+            );
+            selector.parent.insertAfter(
+                selector,
+                parser.className({value : 'a'})
+            );
+        });
+    });
+    t.deepEqual(out, '.b,.x,.a,.b, .y,.a');
+});
+
 test('container#walk', (t) => {
     let str = '';
     parse('h1, h2:not(h3, h4)', (selectors) => {

--- a/src/selectors/container.js
+++ b/src/selectors/container.js
@@ -76,11 +76,13 @@ export default class Container extends Node {
         let oldIndex = this.index(oldNode);
         this.nodes.splice(oldIndex + 1, 0, newNode);
 
+        newNode.parent = this;
+
         let index;
         for ( let id in this.indexes ) {
             index = this.indexes[id];
             if ( oldIndex <= index ) {
-                this.indexes[id] = index + this.nodes.length;
+                this.indexes[id] = index + 1;
             }
         }
 
@@ -91,11 +93,13 @@ export default class Container extends Node {
         let oldIndex = this.index(oldNode);
         this.nodes.splice(oldIndex, 0, newNode);
 
+        newNode.parent = this;
+
         let index;
         for ( let id in this.indexes ) {
             index = this.indexes[id];
-            if ( oldIndex <= index ) {
-                this.indexes[id] = index + this.nodes.length;
+            if ( index <= oldIndex ) {
+                this.indexes[id] = index + 1;
             }
         }
 


### PR DESCRIPTION
Went and took a closer look at what was happening in `container.each()` when inserting elements, turns out the `indexes` value for the container was suddenly getting bigger than the number of nodes within it, which would exit out of the `.each()` loop.

The test `container#insertAfter (during iteration)` was passing with this bug because it doesn't modify the number of nodes for any level of the hierarchy that would need to continue iterating.

I took a stab at adjusting the index in a more-correct way, it passes all the existing tests along with the new test I added.

I also changed it so that newly-inserted nodes in a container would have a valid `parent` property since that bit me more than once while working on this. Happy to remove that if you don't want it in there.

Fixes #86