### PR TITLE
The parent should be set when inserting a node.

### DIFF
--- a/src/__tests__/container.js
+++ b/src/__tests__/container.js
@@ -249,6 +249,16 @@ test('container#insertBefore', (t) => {
     t.deepEqual(out, 'h1,h2');
 });
 
+test('container#insertBefore and node#remove', (t) => {
+    let out = parse('h2', (selectors) => {
+        let selector = selectors.first;
+        let newSel = parser.tag({value: 'h1'});
+        selectors.insertBefore(selector, newSel);
+        newSel.remove();
+    });
+    t.deepEqual(out, 'h2');
+});
+
 test('container#insertAfter', (t) => {
     let out = parse('h1', (selectors) => {
         let selector = selectors.first;
@@ -256,6 +266,16 @@ test('container#insertAfter', (t) => {
         selectors.insertAfter(selector, clone);
     });
     t.deepEqual(out, 'h1,h2');
+});
+
+test('container#insertAfter and node#remove', (t) => {
+    let out = parse('h2', (selectors) => {
+        let selector = selectors.first;
+        let newSel = parser.tag({value: 'h1'});
+        selectors.insertAfter(selector, newSel);
+        newSel.remove();
+    });
+    t.deepEqual(out, 'h2');
 });
 
 test('container#insertAfter (during iteration)', (t) => {

--- a/src/selectors/container.js
+++ b/src/selectors/container.js
@@ -73,6 +73,7 @@ export default class Container extends Node {
     }
 
     insertAfter (oldNode, newNode) {
+        newNode.parent = this;
         let oldIndex = this.index(oldNode);
         this.nodes.splice(oldIndex + 1, 0, newNode);
 
@@ -88,6 +89,7 @@ export default class Container extends Node {
     }
 
     insertBefore (oldNode, newNode) {
+        newNode.parent = this;
         let oldIndex = this.index(oldNode);
         this.nodes.splice(oldIndex, 0, newNode);
 


### PR DESCRIPTION
The parent wasn't getting set during inserts but this wasn't noticed I think because many of the tests are cloning an existing selector instead of creating them from the factory methods. But I suspect this may be the source of other issues because the parent would have also been left set to an inconsistent value in other situations. I added a couple tests to show how you weren't able to remove a node once inserted because the parent attribute wasn't set.