### PR TITLE
Stop interpreting Less interpolations as tags

### DIFF
--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -29,3 +29,9 @@ test('extraneous non-combinating whitespace', '  .h1   ,  .h2   ', (t, tree) => 
     t.deepEqual(tree.nodes[1].nodes[0].spaces.before, '  ');
     t.deepEqual(tree.nodes[1].nodes[0].spaces.after, '   ');
 });
+
+test('Less interpolation within a class', '.foo@{bar}', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes.length, 1);
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo@{bar}');
+});

--- a/src/__tests__/id.js
+++ b/src/__tests__/id.js
@@ -51,3 +51,9 @@ test('Sass interpolation within an id', '#foo#{bar}', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, 'id');
     t.deepEqual(tree.nodes[0].nodes[0].value, 'foo#{bar}');
 });
+
+test('Less interpolation within an id', '#foo@{bar}', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes.length, 1);
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'id');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo@{bar}');
+});

--- a/src/__tests__/nonstandard.js
+++ b/src/__tests__/nonstandard.js
@@ -8,9 +8,8 @@ test('non-standard selector', '.icon.is-$(network)', (t, tree) => {
 });
 
 test('at word in selector', 'em@il.com', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].value, 'em');
-    t.deepEqual(tree.nodes[0].nodes[1].value, '@il');
-    t.deepEqual(tree.nodes[0].nodes[2].value, 'com');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'em@il');
+    t.deepEqual(tree.nodes[0].nodes[1].value, 'com');
 });
 
 test('leading combinator', '> *', (t, tree) => {

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -22,7 +22,7 @@ let singleQuote  = "'".charCodeAt(0),
     ampersand    = '&'.charCodeAt(0),
     at           = '@'.charCodeAt(0),
     atEnd        = /[ \n\t\r\{\(\)'"\\;/]/g,
-    wordEnd      = /[ \n\t\r\(\)\*:;@!&'"\+\|~>,\[\]\\]|\/(?=\*)/g;
+    wordEnd      = /[ \n\t\r\(\)\*:;!&'"\+\|~>,\[\]\\]|\/(?=\*)/g;
 
 export default function tokenize (input) {
     let tokens = [];


### PR DESCRIPTION
I think the issue originally stemmed from the way `@` was marking the end of a word during the tokenization step. I removed that which required a minor test change since it's no longer splitting words on `@` thus emitting two nodes instead of three.

Let me know if you'd like another approach to it or if this is good!

Closes #109.