### PR TITLE
Escape handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -639,7 +639,7 @@ then the raw for that space is set accordingly.
 
 Setting an attribute's property `raws` value to be deleted.
 
-For now, changing the spaces required also updating or removing any of the 
+For now, changing the spaces required also updating or removing any of the
 raws values that override them.
 
 Example: `[ /*before*/ href /* after-attr */ = /* after-operator */ te/*inside-value*/st/* wow */ /*omg*/i/*bbq*/ /*whodoesthis*/]` would parse as:
@@ -789,7 +789,7 @@ postcss(plugin()).process(`
 `.trim(), {from: 'test.css'}).catch((e) => console.error(e.toString()));
 
 // CssSyntaxError: classValidator: ./test.css:1:5: classes may not have underscores or dashes in them
-// 
+//
 // > 1 | .foo-bar {
 //     |     ^
 //   2 |   color: red;
@@ -828,7 +828,7 @@ postcss(plugin()).process(`
 `.trim(), {from: 'test.css'}).catch((e) => console.error(e.toString()));
 
 // CssSyntaxError: classValidator: ./test.css:1:5: classes may not have underscores or dashes in them
-// 
+//
 // > 1 | .foo-bar {
 //     |     ^
 //   2 |   color: red;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,7 +2116,7 @@
         "lodash.flattendeep": "4.4.0",
         "lodash.merge": "4.6.0",
         "md5-hex": "2.0.0",
-        "semver": "5.3.0",
+        "semver": "5.5.0",
         "well-known-symbols": "1.0.0"
       }
     },
@@ -5074,7 +5074,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -6866,7 +6866,7 @@
         "got": "5.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "semver": "5.5.0"
       }
     },
     "parse-glob": {
@@ -7549,9 +7549,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "semver-diff": {
@@ -7560,7 +7560,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.3.0"
+        "semver": "5.5.0"
       }
     },
     "set-immediate-shim": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,6 +2225,11 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "cssesc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-1.0.1.tgz",
+      "integrity": "sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA=="
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "glob": "^7.0.3",
     "minimist": "^1.2.0",
     "nyc": "^11.4.1",
-    "postcss": "^6.0.6"
+    "postcss": "^6.0.6",
+    "semver": "^5.5.0"
   },
   "main": "dist/index.js",
   "types": "postcss-selector-parser.d.ts",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "pretest": "eslint src",
     "prepublish": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
+    "lintfix": "eslint --fix src",
     "report": "nyc report --reporter=html",
     "test": "nyc ava src/__tests__/*.js",
     "testone": "ava"

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "pretest": "eslint src",
     "prepublish": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "report": "nyc report --reporter=html",
-    "test": "nyc ava src/__tests__/*.js"
+    "test": "nyc ava src/__tests__/*.js",
+    "testone": "ava"
   },
   "dependencies": {
+    "cssesc": "^1.0.1",
     "indexes-of": "^1.0.1",
     "uniq": "^1.0.1"
   },

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -221,7 +221,7 @@ declare namespace parser {
          */
         readonly namespaceString: string;
     }
-    function isNamespace(node: any): node is ClassName | Attribute | Tag;
+    function isNamespace(node: any): node is Attribute | Tag;
 
     interface Root extends Container<undefined> {
         type: "root";
@@ -246,7 +246,7 @@ declare namespace parser {
     function combinator(opts: NodeOptions): Combinator;
     function isCombinator(node: any): node is Combinator;
 
-    interface ClassName extends Namespace {
+    interface ClassName extends Base {
         type: "class";
     }
     function className(opts: NamespaceOptions): ClassName;

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -157,6 +157,8 @@ declare namespace parser {
         spaces: Spaces;
         source?: NodeSource;
         sourceIndex: number;
+        rawSpaceBefore: string;
+        rawSpaceAfter: string;
         remove(): Node;
         replaceWith(...nodes: Node[]): Node;
         next(): Node;

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -370,7 +370,7 @@ declare namespace parser {
          *
          * You can also change the quotation used for the current value by setting quoteMark.
          **/
-        quoteValue(options?: SmartQuoteMarkOptions): string;
+        getQuotedValue(options?: SmartQuoteMarkOptions): string;
 
         /**
          * Set the unescaped value with the specified quotation options. The value

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -283,7 +283,7 @@ declare namespace parser {
     type QuoteMark = '"' | "'" | null;
     interface PreferredQuoteMarkOptions {
         quoteMark?: QuoteMark;
-        preferSourceFormat?: boolean;
+        preferCurrentQuoteMark?: boolean;
     }
     interface SmartQuoteMarkOptions extends PreferredQuoteMarkOptions {
         smart?: boolean;
@@ -384,7 +384,7 @@ declare namespace parser {
          * mark will be picked that minimizes the number of escapes.
          *
          * If there's no clear winner, the quote mark from these options is used,
-         * then the source quote mark (this is inverted if `preferSourceFormat` is
+         * then the source quote mark (this is inverted if `preferCurrentQuoteMark` is
          * true). If the quoteMark is unspecified, a double quote is used.
          **/
         smartQuoteMark(options: PreferredQuoteMarkOptions): QuoteMark;

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -162,6 +162,33 @@ declare namespace parser {
         next(): Node;
         prev(): Node;
         clone(opts: {[override: string]:any}): Node;
+        /**
+         * Some non-standard syntax doesn't follow normal escaping rules for css,
+         * this allows the escaped value to be specified directly, allowing illegal characters to be
+         * directly inserted into css output.
+         * @param name the property to set
+         * @param value the unescaped value of the property
+         * @param valueEscaped optional. the escaped value of the property.
+         */
+        setPropertyAndEscape(name: string, value: any, valueEscaped: string);
+        /**
+         * When you want a value to passed through to CSS directly. This method
+         * deletes the corresponding raw value causing the stringifier to fallback
+         * to the unescaped value.
+         * @param name the property to set.
+         * @param value The value that is both escaped and unescaped.
+         */
+        setPropertyWithoutEscape(name: string, value: any);
+        /**
+         * Some non-standard syntax doesn't follow normal escaping rules for css.
+         * This allows non standard syntax to be appended to an existing property
+         * by specifying the escaped value. By specifying the escaped value,
+         * illegal characters are allowed to be directly inserted into css output.
+         * @param {string} name the property to set
+         * @param {any} value the unescaped value of the property
+         * @param {string} valueEscaped optional. the escaped value of the property.
+         */
+        appendToPropertyAndEscape(name, value, valueEscaped);
         toString(): string;
     }
     interface ContainerOptions extends NodeOptions {

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -385,6 +385,6 @@ test('comments within attribute selectors (4)', '[ /*before*/ href /* after-attr
     t.is(attr.raws.value, undefined);
 });
 
-// test('attributes with escapes', '[ng\\:cloak]', (t, tree) => {
-//     t.deepEqual(tree.toString(), '[ng\\:cloak]');
-// });
+test('non standard modifiers', '[href="foo" y]', (t, tree) => {
+    t.deepEqual(tree.toString(), '[href="foo" y]');
+});

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -1,6 +1,6 @@
 import process from "process";
 import Attribute from '../selectors/attribute';
-import {test} from './util/helpers';
+import {test, nodeVersionAtLeast, nodeVersionBefore} from './util/helpers';
 
 process.throwDeprecation = true;
 
@@ -397,7 +397,9 @@ test('non standard modifiers', '[href="foo" y]', (t, tree) => {
     t.deepEqual(tree.toString(), '[href="foo" y]');
 });
 
-test('deprecated constructor', '', (t) => {
+const testDeprecation = nodeVersionAtLeast('7.0.0') || nodeVersionBefore('6.0.0') ? test : test.skip;
+
+testDeprecation('deprecated constructor', '', (t) => {
     t.throws(
         () => {
             return new Attribute({value: '"foo"', attribute: "data-bar"});
@@ -406,7 +408,7 @@ test('deprecated constructor', '', (t) => {
     );
 });
 
-test('deprecated get of raws.unquoted ', '', (t) => {
+testDeprecation('deprecated get of raws.unquoted ', '', (t) => {
     t.throws(
         () => {
             let attr = new Attribute({value: 'foo', quoteMark: '"', attribute: "data-bar"});
@@ -416,7 +418,7 @@ test('deprecated get of raws.unquoted ', '', (t) => {
     );
 });
 
-test('deprecated set of raws.unquoted ', '', (t) => {
+testDeprecation('deprecated set of raws.unquoted ', '', (t) => {
     t.throws(
         () => {
             let attr = new Attribute({value: 'foo', quoteMark: '"', attribute: "data-bar"});
@@ -426,7 +428,7 @@ test('deprecated set of raws.unquoted ', '', (t) => {
     );
 });
 
-test('smart quotes', '[data-foo=bar]', (t, tree) => {
+testDeprecation('smart quotes', '[data-foo=bar]', (t, tree) => {
     let attr = tree.nodes[0].nodes[0];
     attr.setValue('changed', {quoteMark: '"'});
     t.deepEqual(attr.toString(), '[data-foo="changed"]');

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -73,15 +73,15 @@ test('attribute selector with quoted value', '[name="james"]', (t, tree) => {
     t.deepEqual(attr.value, 'james');
     t.deepEqual(attr.quoteMark, '"');
     t.truthy(attr.quoted);
-    t.deepEqual(attr.quoteValue(), '"james"');
+    t.deepEqual(attr.getQuotedValue(), '"james"');
 });
 
 test('attribute selector with escaped quote', '[title="Something \\"weird\\""]', (t, tree) => {
     let attr = tree.nodes[0].nodes[0];
     t.deepEqual(attr.value, 'Something "weird"');
-    t.deepEqual(attr.quoteValue(), '\"Something \\"weird\\"\"');
-    t.deepEqual(attr.quoteValue({smart: true}), '\'Something "weird"\'');
-    t.deepEqual(attr.quoteValue({quoteMark: null}), 'Something\\ \\"weird\\"');
+    t.deepEqual(attr.getQuotedValue(), '\"Something \\"weird\\"\"');
+    t.deepEqual(attr.getQuotedValue({smart: true}), '\'Something "weird"\'');
+    t.deepEqual(attr.getQuotedValue({quoteMark: null}), 'Something\\ \\"weird\\"');
     t.deepEqual(attr.quoteMark, '"');
     t.truthy(attr.quoted);
     t.deepEqual(attr.raws.value, '"Something \\"weird\\""');
@@ -169,7 +169,7 @@ test('attribute selector with quoted value containing "="', '[data-weird-attr="S
     t.deepEqual(tree.nodes[0].nodes[0].operator, '=');
     t.deepEqual(tree.nodes[0].nodes[0].value, 'Something=weird');
     t.is(tree.nodes[0].nodes[0].quoteMark, '"');
-    t.deepEqual(tree.nodes[0].nodes[0].quoteValue(), '"Something=weird"');
+    t.deepEqual(tree.nodes[0].nodes[0].getQuotedValue(), '"Something=weird"');
 });
 
 let selector = '[data-weird-attr*="Something=weird"],' +
@@ -377,7 +377,7 @@ test('comments within attribute selectors (4)', '[ /*before*/ href /* after-attr
     let attr = tree.nodes[0].nodes[0];
     t.deepEqual(attr.attribute, 'href');
     t.deepEqual(attr.value, 'test');
-    t.deepEqual(attr.quoteValue(), 'test');
+    t.deepEqual(attr.getQuotedValue(), 'test');
     t.deepEqual(attr.raws.value, 'te/*inside-value*/st');
     t.deepEqual(attr.raws.spaces.value.after, '/* wow */ /*omg*/');
     t.truthy(attr.insensitive);

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -64,7 +64,6 @@ test('attribute selector with a value', '[name=james]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].operator, '=');
     t.deepEqual(tree.nodes[0].nodes[0].value, 'james');
     t.falsy(tree.nodes[0].nodes[0].quoted);
-    t.deepEqual(tree.nodes[0].nodes[0].raws.unquoted, 'james');
 });
 
 test('attribute selector with quoted value', '[name="james"]', (t, tree) => {
@@ -74,7 +73,6 @@ test('attribute selector with quoted value', '[name="james"]', (t, tree) => {
     t.deepEqual(attr.value, 'james');
     t.deepEqual(attr.quoteMark, '"');
     t.truthy(attr.quoted);
-    t.deepEqual(attr.raws.unquoted, 'james');
     t.deepEqual(attr.quoteValue(), '"james"');
 });
 
@@ -87,7 +85,6 @@ test('attribute selector with escaped quote', '[title="Something \\"weird\\""]',
     t.deepEqual(attr.quoteMark, '"');
     t.truthy(attr.quoted);
     t.deepEqual(attr.raws.value, '"Something \\"weird\\""');
-    t.deepEqual(attr.raws.unquoted, 'Something "weird"');
     t.deepEqual(tree.toString(), '[title="Something \\"weird\\""]');
 });
 
@@ -318,7 +315,6 @@ test('spaces in attribute selectors', 'h1[  href  *=  "test"  ]', (t, tree) => {
     t.deepEqual(attr.value, 'test');
     t.deepEqual(attr.spaces.value.after, '  ');
     t.truthy(tree.nodes[0].nodes[1].quoted);
-    t.deepEqual(tree.nodes[0].nodes[1].raws.unquoted, 'test');
 });
 
 test('insensitive attribute selector 1', '[href="test" i]', (t, tree) => {
@@ -377,8 +373,8 @@ test('comments within attribute selectors (4)', '[ /*before*/ href /* after-attr
     let attr = tree.nodes[0].nodes[0];
     t.deepEqual(attr.attribute, 'href');
     t.deepEqual(attr.value, 'test');
+    t.deepEqual(attr.quoteValue(), 'test');
     t.deepEqual(attr.raws.value, 'te/*inside-value*/st');
-    t.deepEqual(attr.raws.unquoted, 'test');
     t.deepEqual(attr.raws.spaces.value.after, '/* wow */ /*omg*/');
     t.truthy(attr.insensitive);
     t.deepEqual(attr.offsetOf("attribute"), 13);

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -447,3 +447,17 @@ testDeprecation('smart quotes', '[data-foo=bar]', (t, tree) => {
     attr.setValue('smart with "double quotes"', {smart: true});
     t.deepEqual(attr.toString(), "[data-foo='smart with \"double quotes\"']");
 });
+
+testDeprecation('set Attribute#quoteMark', '[data-foo=bar]', (t, tree) => {
+    let attr = tree.nodes[0].nodes[0];
+    attr.quoteMark = '"';
+    t.deepEqual(attr.toString(), '[data-foo="bar"]');
+    attr.quoteMark = "'";
+    t.deepEqual(attr.toString(), "[data-foo='bar']");
+    attr.quoteMark = null;
+    t.deepEqual(attr.toString(), "[data-foo=bar]");
+    attr.value = "has space";
+    t.deepEqual(attr.toString(), "[data-foo=has\\ space]");
+    attr.quoteMark = '"';
+    t.deepEqual(attr.toString(), '[data-foo="has space"]');
+});

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -388,3 +388,9 @@ test('comments within attribute selectors (4)', '[ /*before*/ href /* after-attr
 test('non standard modifiers', '[href="foo" y]', (t, tree) => {
     t.deepEqual(tree.toString(), '[href="foo" y]');
 });
+
+// This is a test case that fails in prettier. Not sure how to support it because I don't know that the range of allowed syntax is.
+// And even then, I'm not sure it makes sense.
+// test.skip('[nonstandard] function as attribute value', "[id=func('foo')]", (t, tree) => {
+//     t.deepEqual(tree.toString(), '[href="foo" y]');
+// });

--- a/src/__tests__/attributes.js
+++ b/src/__tests__/attributes.js
@@ -334,6 +334,10 @@ test('insensitive attribute selector 3', '[href=test i]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, 'test');
     t.deepEqual(tree.nodes[0].nodes[0].insensitive, true);
 });
+test('capitalized insensitive attribute selector 3', '[href=test I]', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'test');
+    t.deepEqual(tree.nodes[0].nodes[0].insensitive, true);
+});
 
 test('extraneous non-combinating whitespace', '  [href]   ,  [class]   ', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');

--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -37,12 +37,9 @@ test('Less interpolation within a class', '.foo@{bar}', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, 'foo@{bar}');
 });
 
-test('ClassName#set value', (t) => {
-    let out = parse('.fo\\o', (selectors) => {
-        let className = selectors.first.first;
-        t.deepEqual(className.raws, {value: "fo\\o"});
-        className.value = "bar";
-        t.deepEqual(className.raws, {});
-    });
-    t.deepEqual(out, '.bar');
+test('ClassName#set value', ".fo\\o", (t, selectors) => {
+    let className = selectors.first.first;
+    t.deepEqual(className.raws, {value: "fo\\o"});
+    className.value = "bar";
+    t.deepEqual(className.raws, {});
 });

--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -36,3 +36,13 @@ test('Less interpolation within a class', '.foo@{bar}', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
     t.deepEqual(tree.nodes[0].nodes[0].value, 'foo@{bar}');
 });
+
+test('ClassName#set value', (t) => {
+    let out = parse('.fo\\o', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, {value: "fo\\o"});
+        className.value = "bar";
+        t.deepEqual(className.raws, {});
+    });
+    t.deepEqual(out, '.bar');
+});

--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -18,7 +18,8 @@ test('qualified class', 'button.btn-primary', (t, tree) => {
 
 test('escaped numbers in class name', '.\\31\\ 0', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
-    t.deepEqual(tree.nodes[0].nodes[0].value, '\\31\\ 0');
+    t.deepEqual(tree.nodes[0].nodes[0].value, '1 0');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\31\\ 0');
 });
 
 test('extraneous non-combinating whitespace', '  .h1   ,  .h2   ', (t, tree) => {

--- a/src/__tests__/combinators.js
+++ b/src/__tests__/combinators.js
@@ -87,3 +87,21 @@ test('trailing combinator & spaces', 'p +        ', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, 'p', 'should be a paragraph');
     t.deepEqual(tree.nodes[0].nodes[1].value, '+', 'should have a combinator');
 });
+test('ending in comment has no trailing combinator', ".bar /* comment 3 */", (t, tree) => {
+    let nodeTypes = tree.nodes[0].map(n => n.type);
+    t.deepEqual(nodeTypes, ["class"]);
+});
+test('with spaces and a comment has only one combinator', ".bar /* comment 3 */ > .foo", (t, tree) => {
+    let nodeTypes = tree.nodes[0].map(n => n.type);
+    t.deepEqual(nodeTypes, ["class", "combinator", "class"]);
+});
+
+test('with a meaningful comment in the middle of a compound selector', "div/* wtf */.foo", (t, tree) => {
+    let nodeTypes = tree.nodes[0].map(n => n.type);
+    t.deepEqual(nodeTypes, ["tag", "comment", "class"]);
+});
+
+test('with a comment in the middle of a descendant selector', "div/* wtf */ .foo", (t, tree) => {
+    let nodeTypes = tree.nodes[0].map(n => n.type);
+    t.deepEqual(nodeTypes, ["tag", "comment", "combinator", "class"]);
+});

--- a/src/__tests__/comments.js
+++ b/src/__tests__/comments.js
@@ -13,3 +13,10 @@ test('multiple comments and other things', 'h1/*test*/h2/*test*/.test/*test*/', 
     t.deepEqual(tree.nodes[0].nodes[4].type, 'class', 'should have a class name');
     t.deepEqual(tree.nodes[0].nodes[5].type, 'comment', 'should have a comment');
 });
+
+test('ending in comment', ".bar /* comment 3 */", (t, tree) => {
+    let classname = tree.nodes[0].nodes[0];
+    t.deepEqual(classname.type, 'class', 'should have a tag');
+    t.deepEqual(classname.spaces.after, ' ');
+    t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */');
+});

--- a/src/__tests__/escapes.js
+++ b/src/__tests__/escapes.js
@@ -1,12 +1,13 @@
 import {test} from './util/helpers';
 
-test('escaped semicolon', '.\\;', (t, tree) => {
+test('escaped semicolon in class', '.\\;', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, ';');
     t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\;');
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
 });
 
-test('escaped semicolon', '#\\;', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].value, '\\;');
+test('escaped semicolon in id', '#\\;', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, ';');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\;');
     t.deepEqual(tree.nodes[0].nodes[0].type, 'id');
 });

--- a/src/__tests__/escapes.js
+++ b/src/__tests__/escapes.js
@@ -11,3 +11,9 @@ test('escaped semicolon in id', '#\\;', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\;');
     t.deepEqual(tree.nodes[0].nodes[0].type, 'id');
 });
+
+// This is a side-effect of allowing media queries to be parsed. Not sure it shouldn't just be an error.
+test('bare parens capture contents as a string', '(h1)', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '(h1)');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'string');
+});

--- a/src/__tests__/escapes.js
+++ b/src/__tests__/escapes.js
@@ -1,7 +1,8 @@
 import {test} from './util/helpers';
 
 test('escaped semicolon', '.\\;', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].value, '\\;');
+    t.deepEqual(tree.nodes[0].nodes[0].value, ';');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\;');
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
 });
 

--- a/src/__tests__/guards.js
+++ b/src/__tests__/guards.js
@@ -18,7 +18,7 @@ test('className guard', '.foo', (t, tree) => {
     t.false(parser.isClassName(undefined));
     t.true(parser.isClassName(n));
     t.false(parser.isContainer(n));
-    t.true(parser.isNamespace(n));
+    t.false(parser.isNamespace(n));
 });
 
 test('combinator guard', '.foo > .bar', (t, tree) => {

--- a/src/__tests__/lossy.js
+++ b/src/__tests__/lossy.js
@@ -73,6 +73,9 @@ ava('pseudo - negated with combinators (1)', testLossy, 'h1:not(.heading > .titl
 ava('pseudo - negated with combinators (2)', testLossy, '.foo:nth-child(2n + 1)', '.foo:nth-child(2n+1)');
 ava('pseudo - extra whitespace', testLossy, 'a:not(   h2   )', 'a:not(h2)');
 
+ava('comments - comment inside descendant selector', testLossy, "div /* wtf */.foo", "div /* wtf */.foo");
+ava('comments - comment inside complex selector', testLossy, "div /* wtf */ > .foo", "div/* wtf */>.foo");
+ava('comments - comment inside compound selector with space', testLossy, "div    /* wtf */    .foo", "div /* wtf */ .foo");
 ava('@words - space before', testLossy, '  @media', '@media');
 ava('@words - space after', testLossy, '@media  ', '@media');
 ava('@words - maintains space between', testLossy, '@media (min-width: 700px) and (orientation: landscape)', '@media (min-width: 700px) and (orientation: landscape)');

--- a/src/__tests__/lossy.js
+++ b/src/__tests__/lossy.js
@@ -52,7 +52,7 @@ ava('tag - extraneous whitespace', testLossy, '  h1   ,  h2   ', 'h1,h2');
 ava('tag - trailing comma', testLossy, 'h1, ', 'h1,');
 ava('tag - trailing comma (1)', testLossy, 'h1,', 'h1,');
 ava('tag - trailing comma (2)', testLossy, 'h1', 'h1');
-ava('tag - trailing slash (1)', testLossy, 'h1\\    ', 'h1\\');
+ava('tag - trailing slash (1)', testLossy, 'h1\\    ', 'h1\\ ');
 ava('tag - trailing slash (2)', testLossy, 'h1\\    h2\\', 'h1\\  h2\\');
 
 ava('universal - combinator', testLossy, ' * + * ', '*+*');

--- a/src/__tests__/lossy.js
+++ b/src/__tests__/lossy.js
@@ -77,3 +77,4 @@ ava('@words - space before', testLossy, '  @media', '@media');
 ava('@words - space after', testLossy, '@media  ', '@media');
 ava('@words - maintains space between', testLossy, '@media (min-width: 700px) and (orientation: landscape)', '@media (min-width: 700px) and (orientation: landscape)');
 ava('@words - extraneous space between', testLossy, '@media  (min-width:  700px)  and   (orientation:   landscape)', '@media (min-width: 700px) and (orientation: landscape)');
+ava('@words - multiple', testLossy, '@media (min-width: 700px), (min-height: 400px)', '@media (min-width: 700px),(min-height: 400px)');

--- a/src/__tests__/lossy.js
+++ b/src/__tests__/lossy.js
@@ -53,7 +53,7 @@ ava('tag - trailing comma', testLossy, 'h1, ', 'h1,');
 ava('tag - trailing comma (1)', testLossy, 'h1,', 'h1,');
 ava('tag - trailing comma (2)', testLossy, 'h1', 'h1');
 ava('tag - trailing slash (1)', testLossy, 'h1\\    ', 'h1\\');
-ava('tag - trailing slash (2)', testLossy, 'h1\\    h2\\', 'h1\\ h2\\');
+ava('tag - trailing slash (2)', testLossy, 'h1\\    h2\\', 'h1\\  h2\\');
 
 ava('universal - combinator', testLossy, ' * + * ', '*+*');
 ava('universal - extraneous whitespace', testLossy, '  *   ,  *   ', '*,*');

--- a/src/__tests__/namespaces.js
+++ b/src/__tests__/namespaces.js
@@ -67,3 +67,12 @@ test('namespace with qualified id selector', 'ns|h1#foo', (t, tree) => {
 test('namespace with qualified class selector', 'ns|h1.foo', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].namespace, 'ns');
 });
+
+test('ns alias for namespace', 'f\\oo|h1.foo', (t, tree) => {
+    let tag = tree.nodes[0].nodes[0];
+    t.deepEqual(tag.namespace, 'foo');
+    t.deepEqual(tag.ns, 'foo');
+    tag.ns = "bar";
+    t.deepEqual(tag.namespace, 'bar');
+    t.deepEqual(tag.ns, 'bar');
+});

--- a/src/__tests__/namespaces.js
+++ b/src/__tests__/namespaces.js
@@ -50,7 +50,12 @@ test('match namespace inside attribute selector (3)', '[*|href]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');
 });
 
-test('match namespace inside attribute selector (4)', '[|href]', (t, tree) => {
+test('match default namespace inside attribute selector', '[|href]', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].namespace, true);
+    t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');
+});
+
+test('match default namespace inside attribute selector with spaces', '[ |href ]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].namespace, true);
     t.deepEqual(tree.nodes[0].nodes[0].attribute, 'href');
 });

--- a/src/__tests__/nesting.js
+++ b/src/__tests__/nesting.js
@@ -34,3 +34,10 @@ test('&_foo', '&_foo', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[1].value, '_foo');
     t.deepEqual(tree.nodes[0].nodes[1].type, 'tag');
 });
+
+test('&|foo', '&|foo', (t, tree) => {
+    let element = tree.nodes[0].nodes[0];
+    t.deepEqual(element.value, 'foo');
+    t.deepEqual(element.type, 'tag');
+    t.deepEqual(element.namespace, '&');
+});

--- a/src/__tests__/node.js
+++ b/src/__tests__/node.js
@@ -20,3 +20,54 @@ test('node#replaceWith', (t) => {
     });
     t.deepEqual(out, '#test.test');
 });
+
+test('Node#appendToPropertyAndEscape', (t) => {
+    let out = parse('.fo\\o', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, {value: "fo\\o"});
+        className.appendToPropertyAndEscape("value", "bar", "ba\\r");
+        t.deepEqual(className.raws, {value: "fo\\oba\\r"});
+    });
+    t.deepEqual(out, '.fo\\oba\\r');
+});
+
+test('Node#setPropertyAndEscape with existing raws', (t) => {
+    let out = parse('.fo\\o', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, {value: "fo\\o"});
+        className.setPropertyAndEscape("value", "bar", "ba\\r");
+        t.deepEqual(className.raws, {value: "ba\\r"});
+    });
+    t.deepEqual(out, '.ba\\r');
+});
+
+test('Node#setPropertyAndEscape without existing raws', (t) => {
+    let out = parse('.foo', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, undefined);
+        className.setPropertyAndEscape("value", "bar", "ba\\r");
+        t.deepEqual(className.raws, {value: "ba\\r"});
+    });
+    t.deepEqual(out, '.ba\\r');
+});
+
+test('Node#setPropertyWithoutEscape with existing raws', (t) => {
+    let out = parse('.fo\\o', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, {value: "fo\\o"});
+        className.setPropertyWithoutEscape("value", "w+t+f");
+        t.deepEqual(className.raws, {});
+    });
+    t.deepEqual(out, '.w+t+f');
+});
+
+test('Node#setPropertyWithoutEscape without existing raws', (t) => {
+    let out = parse('.foo', (selectors) => {
+        let className = selectors.first.first;
+        t.deepEqual(className.raws, undefined);
+        className.setPropertyWithoutEscape("value", "w+t+f");
+        t.deepEqual(className.raws, {});
+        t.deepEqual(className.value, "w+t+f");
+    });
+    t.deepEqual(out, '.w+t+f');
+});

--- a/src/__tests__/nonstandard.js
+++ b/src/__tests__/nonstandard.js
@@ -1,10 +1,12 @@
 import {test} from './util/helpers';
 
 test('non-standard selector', '.icon.is-$(network)', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].value, 'icon');
-    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
-    t.deepEqual(tree.nodes[0].nodes[1].value, 'is-$(network)');
-    t.deepEqual(tree.nodes[0].nodes[1].type, 'class');
+    let class1 = tree.nodes[0].nodes[0];
+    t.deepEqual(class1.value, 'icon');
+    t.deepEqual(class1.type, 'class');
+    let class2 = tree.nodes[0].nodes[1];
+    t.deepEqual(class2.value, 'is-$(network)');
+    t.deepEqual(class2.type, 'class');
 });
 
 test('at word in selector', 'em@il.com', (t, tree) => {

--- a/src/__tests__/postcss.js
+++ b/src/__tests__/postcss.js
@@ -27,7 +27,6 @@ test('string after colon (incorrect pseudo)', showCode, 'a b:"wow" {}');
 
 // attribute selectors
 
-test('bad whitespace instead of namespace token', showCode, '[  |href=test] {}');
 test('bad string attribute', showCode, '["hello"] {}');
 test('bad string attribute with value', showCode, '["foo"=bar] {}');
 test('bad parentheses', showCode, '[foo=(bar)] {}');

--- a/src/__tests__/pseudos.js
+++ b/src/__tests__/pseudos.js
@@ -61,7 +61,8 @@ test('extra whitespace inside parentheses', 'a:not(   h2   )', (t, tree) => {
 
 test('escaped numbers in class name with pseudo', 'a:before.\\31\\ 0', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[2].type, 'class');
-    t.deepEqual(tree.nodes[0].nodes[2].value, '\\31\\ 0');
+    t.deepEqual(tree.nodes[0].nodes[2].value, '1 0');
+    t.deepEqual(tree.nodes[0].nodes[2].raws.value, '\\31\\ 0');
 });
 
 test('nested pseudo', '.btn-group>.btn:last-child:not(:first-child)', (t, tree) => {

--- a/src/__tests__/util/helpers.js
+++ b/src/__tests__/util/helpers.js
@@ -6,21 +6,16 @@ export const parse = (input, transform) => {
     return parser(transform).processSync(input);
 };
 
-export function test (spec, input, callback, only = false, disabled = false) {
+export function test (spec, input, callback, only = false, disabled = false, serial = false) {
     let tester = only ? ava.only : ava;
-    if (disabled) {
-        tester = ava.skip;
-    }
-    if (only) {
-        let e = new Error();
-        console.error(e);
-    }
+    tester = disabled ? tester.skip : tester;
+    tester = serial ? tester.serial : tester;
 
     if (callback) {
         tester(`${spec} (tree)`, t => {
             let tree = parser().astSync(input);
             let debug = util.inspect(tree, false, null);
-            callback.call(this, t, tree, debug);
+            return callback.call(this, t, tree, debug);
         });
     }
 
@@ -32,6 +27,7 @@ export function test (spec, input, callback, only = false, disabled = false) {
 
 test.only = (spec, input, callback) => test(spec, input, callback, true);
 test.skip = (spec, input, callback) => test(spec, input, callback, false, true);
+test.serial = (spec, input, callback) => test(spec, input, callback, false, false, true);
 
 export const throws = (spec, input, validator) => {
     ava(`${spec} (throws)`, t => {

--- a/src/__tests__/util/helpers.js
+++ b/src/__tests__/util/helpers.js
@@ -1,5 +1,7 @@
+import process from 'process';
 import util from 'util';
 import ava from 'ava';
+import semver from 'semver';
 import parser from '../../index';
 
 export const parse = (input, transform) => {
@@ -34,3 +36,11 @@ export const throws = (spec, input, validator) => {
         t.throws(() => parser().processSync(input), validator);
     });
 };
+
+export function nodeVersionAtLeast (version) {
+    return semver.gte(process.versions.node, version);
+}
+
+export function nodeVersionBefore (version) {
+    return semver.lt(process.versions.node, version);
+}

--- a/src/__tests__/util/helpers.js
+++ b/src/__tests__/util/helpers.js
@@ -29,8 +29,8 @@ export function test (spec, input, callback, only = false) {
 
 test.only = (spec, input, callback) => test(spec, input, callback, true);
 
-export const throws = (spec, input) => {
+export const throws = (spec, input, validator) => {
     ava(`${spec} (throws)`, t => {
-        t.throws(() => parser().processSync(input));
+        t.throws(() => parser().processSync(input), validator);
     });
 };

--- a/src/__tests__/util/helpers.js
+++ b/src/__tests__/util/helpers.js
@@ -6,8 +6,11 @@ export const parse = (input, transform) => {
     return parser(transform).processSync(input);
 };
 
-export function test (spec, input, callback, only = false) {
+export function test (spec, input, callback, only = false, disabled = false) {
     let tester = only ? ava.only : ava;
+    if (disabled) {
+        tester = ava.skip;
+    }
     if (only) {
         let e = new Error();
         console.error(e);
@@ -28,6 +31,7 @@ export function test (spec, input, callback, only = false) {
 }
 
 test.only = (spec, input, callback) => test(spec, input, callback, true);
+test.skip = (spec, input, callback) => test(spec, input, callback, false, true);
 
 export const throws = (spec, input, validator) => {
     ava(`${spec} (throws)`, t => {

--- a/src/parser.js
+++ b/src/parser.js
@@ -36,7 +36,10 @@ function getSource (startLine, startColumn, endLine, endColumn) {
 
 function unescapeProp (node, prop) {
     let value = node[prop];
-    if (value && value.indexOf("\\") !== -1) {
+    if (typeof value !== "string") {
+        return;
+    }
+    if (value.indexOf("\\") !== -1) {
         ensureObject(node, 'raws');
         if (node.raws[prop] === undefined) {
             node.raws[prop] = value;

--- a/src/parser.js
+++ b/src/parser.js
@@ -275,10 +275,11 @@ export default class Parser {
                     }
                     lastAdded = 'value';
                 } else {
-                    let insensitive = (content === 'i');
+                    let insensitive = (content === 'i' || content === "I");
                     if (node.value && (node.quoteMark || spaceAfterMeaningfulToken)) {
-                        node.insensitive = true;
-                        if (!insensitive) {
+                        node.insensitive = insensitive;
+                        if (!insensitive || content === "I") {
+                            ensureObject(node, 'raws');
                             node.raws.insensitiveFlag = content;
                         }
                         lastAdded = 'insensitive';

--- a/src/parser.js
+++ b/src/parser.js
@@ -410,6 +410,13 @@ export default class Parser {
     }
 
     nesting () {
+        if (this.nextToken) {
+            let nextContent = this.content(this.nextToken);
+            if (nextContent === "|") {
+                this.position++;
+                return;
+            }
+        }
         const current = this.currToken;
         this.newNode(new Nesting({
             value: this.content(),

--- a/src/parser.js
+++ b/src/parser.js
@@ -63,10 +63,10 @@ function unescapeProp (node, prop) {
     }
     if (value.indexOf("\\") !== -1) {
         ensureObject(node, 'raws');
+        node[prop] = unesc(value);
         if (node.raws[prop] === undefined) {
             node.raws[prop] = value;
         }
-        node[prop] = unesc(value);
     }
     return node;
 }
@@ -761,7 +761,8 @@ export default class Parser {
                     source,
                     sourceIndex,
                 };
-                node = new Tag(unescapeProp(tagOpts, "value"));
+                unescapeProp(tagOpts, "value");
+                node = new Tag(tagOpts);
             }
             this.newNode(node, namespace);
             // Ensure that the namespace is used only once
@@ -885,6 +886,7 @@ export default class Parser {
                 namespace = true;
             }
             node.namespace = namespace;
+            unescapeProp(node, "namespace");
         }
         if (this.spaces) {
             node.spaces.before = this.spaces;

--- a/src/parser.js
+++ b/src/parser.js
@@ -46,6 +46,7 @@ function unescapeProp (node, prop) {
         }
         node[prop] = unesc(value);
     }
+    return node;
 }
 
 export default class Parser {
@@ -614,23 +615,19 @@ export default class Parser {
                 current[2] + (index - 1)
             );
             if (~hasClass.indexOf(ind)) {
-                let v = value.slice(1);
-                let u = unesc(v);
                 let classNameOpts = {
-                    value: u,
-                    source,
-                    sourceIndex,
-                };
-                if (v !== u) {
-                    classNameOpts.raws = {value: v};
-                }
-                node = new ClassName(classNameOpts);
-            } else if (~hasId.indexOf(ind)) {
-                node = new ID({
                     value: value.slice(1),
                     source,
                     sourceIndex,
-                });
+                };
+                node = new ClassName(unescapeProp(classNameOpts, "value"));
+            } else if (~hasId.indexOf(ind)) {
+                let idOpts = {
+                    value: value.slice(1),
+                    source,
+                    sourceIndex,
+                };
+                node = new ID(unescapeProp(idOpts, "value"));
             } else {
                 node = new Tag({
                     value,

--- a/src/parser.js
+++ b/src/parser.js
@@ -247,9 +247,13 @@ export default class Parser {
                         node.raws.value = (oldRawValue || oldValue) + content;
                     }
                     lastAdded = 'value';
-                } else if (content === 'i') {
+                } else {
+                    let insensitive = (content === 'i');
                     if (node.value && (node.quoteMark || spaceAfterMeaningfulToken)) {
                         node.insensitive = true;
+                        if (!insensitive) {
+                            node.raws.insensitiveFlag = content;
+                        }
                         lastAdded = 'insensitive';
                         if (spaceBefore) {
                             ensureObject(node, 'spaces', 'insensitive');
@@ -264,9 +268,9 @@ export default class Parser {
                         }
                     } else if (node.value) {
                         lastAdded = 'value';
-                        node.value += 'i';
+                        node.value += content;
                         if (node.raws.value) {
-                            node.raws.value += 'i';
+                            node.raws.value += content;
                         }
                     }
                 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -458,7 +458,7 @@ export default class Parser {
             }
             this.current = cache;
         } else {
-            last.value += '(';
+            last.appendToPropertyAndEscape("value", '(', '(');
             while (this.position < this.tokens.length && balanced) {
                 if (this.currToken[0] === tokens.openParenthesis) {
                     balanced ++;
@@ -466,7 +466,8 @@ export default class Parser {
                 if (this.currToken[0] === tokens.closeParenthesis) {
                     balanced --;
                 }
-                last.value += this.parseParenthesisToken(this.currToken);
+                let additionalValue = this.parseParenthesisToken(this.currToken);
+                last.appendToPropertyAndEscape("value", additionalValue, additionalValue);
                 this.position ++;
             }
         }
@@ -613,11 +614,17 @@ export default class Parser {
                 current[2] + (index - 1)
             );
             if (~hasClass.indexOf(ind)) {
-                node = new ClassName({
-                    value: value.slice(1),
+                let v = value.slice(1);
+                let u = unesc(v);
+                let classNameOpts = {
+                    value: u,
                     source,
                     sourceIndex,
-                });
+                };
+                if (v !== u) {
+                    classNameOpts.raws = {value: v};
+                }
+                node = new ClassName(classNameOpts);
             } else if (~hasId.indexOf(ind)) {
                 node = new ID({
                     value: value.slice(1),

--- a/src/processor.js
+++ b/src/processor.js
@@ -71,7 +71,7 @@ export default class Processor {
 
     /**
      * Process rule into a selector AST.
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {Promise<parser.Root>} The AST of the selector after processing it.
@@ -82,7 +82,7 @@ export default class Processor {
 
     /**
      * Process rule into a selector AST synchronously.
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {parser.Root} The AST of the selector after processing it.
@@ -93,7 +93,7 @@ export default class Processor {
 
     /**
      * Process a selector into a transformed value asynchronously
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {Promise<any>} The value returned by the processor.
@@ -104,7 +104,7 @@ export default class Processor {
 
     /**
      * Process a selector into a transformed value synchronously.
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {any} The value returned by the processor.
@@ -115,7 +115,7 @@ export default class Processor {
 
     /**
      * Process a selector into a new selector string asynchronously.
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {string} the selector after processing.
@@ -127,7 +127,7 @@ export default class Processor {
 
     /**
      * Process a selector into a new selector string synchronously.
-     * 
+     *
      * @param rule {postcss.Rule | string} The css selector to be processed
      * @param options The options for processing
      * @returns {string} the selector after processing.

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -273,22 +273,6 @@ export default class Attribute extends Namespace {
         }
     }
 
-    get namespace () {
-        return this._namespace;
-    }
-
-    set namespace (v) {
-        if (v === "*") {
-            // Don't escape this special value for the namespace.
-            if (this._constructed) {
-                delete this.raws.namespace;
-            }
-        } else {
-            this._handleEscapes("namespace", v);
-        }
-        this._namespace = v;
-    }
-
     get attribute () {
         return this._attribute;
     }

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -95,7 +95,7 @@ export default class Attribute extends Namespace {
      *     and the other options specified here. See the `smartQuoteMark()`
      *     method.
      **/
-    quoteValue (options = {}) {
+    getQuotedValue (options = {}) {
         let quoteMark = this._determineQuoteMark(options);
         let cssescopts = CSSESC_QUOTE_OPTIONS[quoteMark];
         let escaped = cssesc(this._value, cssescopts);

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -369,7 +369,7 @@ export default class Attribute extends Namespace {
 
     toString () {
         let selector = [
-            this.spaces.before,
+            this.rawSpaceBefore,
             '[',
         ];
 
@@ -390,7 +390,7 @@ export default class Attribute extends Namespace {
         }
 
         selector.push(']');
-        selector.push(this.spaces.after);
+        selector.push(this.rawSpaceAfter);
         return selector.join('');
     }
 }

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -89,7 +89,7 @@ export default class Attribute extends Namespace {
      *     * `null` - the value will be unquoted and characters will be escaped as necessary.
      *     * `'` - the value will be quoted with a single quote and single quotes are escaped.
      *     * `"` - the value will be quoted with a double quote and double quotes are escaped.
-     *   * preferSourceFormat {boolean} - if true, prefer the source quote mark
+     *   * preferCurrentQuoteMark {boolean} - if true, prefer the source quote mark
      *     over the quoteMark option value.
      *   * smart {boolean} - if true, will select a quote mark based on the value
      *     and the other options specified here. See the `smartQuoteMark()`
@@ -122,10 +122,10 @@ export default class Attribute extends Namespace {
      * mark will be picked that minimizes the number of escapes.
      *
      * If there's no clear winner, the quote mark from these options is used,
-     * then the source quote mark (this is inverted if `preferSourceFormat` is
+     * then the source quote mark (this is inverted if `preferCurrentQuoteMark` is
      * true). If the quoteMark is unspecified, a double quote is used.
      *
-     * @param options This takes the quoteMark and preferSourceFormat options
+     * @param options This takes the quoteMark and preferCurrentQuoteMark options
      * from the quoteValue method.
      */
     smartQuoteMark (options) {
@@ -154,10 +154,10 @@ export default class Attribute extends Namespace {
      * instead.
      */
     preferredQuoteMark (options) {
-        let quoteMark = (options.preferSourceFormat) ? this.quoteMark : options.quoteMark;
+        let quoteMark = (options.preferCurrentQuoteMark) ? this.quoteMark : options.quoteMark;
 
         if (quoteMark === undefined) {
-            quoteMark = (options.preferSourceFormat) ? options.quoteMark : this.quoteMark;
+            quoteMark = (options.preferCurrentQuoteMark) ? options.quoteMark : this.quoteMark;
         }
 
         if (quoteMark === undefined) {
@@ -303,7 +303,7 @@ export default class Attribute extends Namespace {
 
     _stringFor (name, spaceName = name, concat = defaultAttrConcat) {
         let attrSpaces = this._spacesFor(spaceName);
-        return concat(this._valueFor(name), attrSpaces);
+        return concat(this.stringifyProperty(name), attrSpaces);
     }
 
     /**
@@ -339,11 +339,11 @@ export default class Attribute extends Namespace {
             return count;
         }
 
-        count += this._valueFor("attribute").length;
+        count += this.stringifyProperty("attribute").length;
         count += attributeSpaces.after.length;
         let operatorSpaces = this._spacesFor("operator");
         count += operatorSpaces.before.length;
-        let operator = this._valueFor("operator");
+        let operator = this.stringifyProperty("operator");
         if (name === "operator") {
             return operator ? count : -1;
         }
@@ -352,7 +352,7 @@ export default class Attribute extends Namespace {
         count += operatorSpaces.after.length;
         let valueSpaces = this._spacesFor("value");
         count += valueSpaces.before.length;
-        let value = this._valueFor("value");
+        let value = this.stringifyProperty("value");
         if (name === "value") {
             return value ? count : -1;
         }

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -300,9 +300,6 @@ export default class Attribute extends Namespace {
         let rawSpaces = (this.raws.spaces && this.raws.spaces[name]) || {};
         return Object.assign(attrSpaces, spaces, rawSpaces);
     }
-    _valueFor (name) {
-        return this.raws[name] || this[name];
-    }
 
     _stringFor (name, spaceName = name, concat = defaultAttrConcat) {
         let attrSpaces = this._spacesFor(spaceName);

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -218,7 +218,9 @@ export default class Attribute extends Namespace {
     _syncRawValue () {
         let rawValue = cssesc(this._value, CSSESC_QUOTE_OPTIONS[this.quoteMark]);
         if (rawValue === this._value) {
-            delete this.raws.value;
+            if (this.raws) {
+                delete this.raws.value;
+            }
         } else {
             this.raws.value = rawValue;
         }
@@ -262,12 +264,8 @@ export default class Attribute extends Namespace {
                 return;
             }
             this._value = unescaped;
-            this.quoteMark = quoteMark;
-            if (unescaped === this._value) {
-                delete this.raws.value;
-            } else {
-                this.raws.value = v;
-            }
+            this._quoteMark = quoteMark;
+            this._syncRawValue();
         } else {
             this._value = v;
         }

--- a/src/selectors/className.js
+++ b/src/selectors/className.js
@@ -1,7 +1,7 @@
-import Namespace from './namespace';
+import Node from './node';
 import {CLASS} from './types';
 
-export default class ClassName extends Namespace {
+export default class ClassName extends Node {
     constructor (opts) {
         super(opts);
         this.type = CLASS;
@@ -10,7 +10,6 @@ export default class ClassName extends Namespace {
     toString () {
         return [
             this.spaces.before,
-            this.ns,
             String('.' + this.value),
             this.spaces.after,
         ].join('');

--- a/src/selectors/className.js
+++ b/src/selectors/className.js
@@ -1,3 +1,5 @@
+import cssesc from "cssesc";
+import {ensureObject} from '../util';
 import Node from './node';
 import {CLASS} from './types';
 
@@ -5,12 +7,30 @@ export default class ClassName extends Node {
     constructor (opts) {
         super(opts);
         this.type = CLASS;
+        this._constructed = true;
+    }
+
+    set value (v) {
+        if (this._constructed) {
+            let escaped = cssesc(v, {isIdentifier: true});
+            if (escaped !== v) {
+                ensureObject(this, "raws");
+                this.raws.value = escaped;
+            } else if (this.raws) {
+                delete this.raws.value;
+            }
+        }
+        this._value = v;
+    }
+
+    get value () {
+        return this._value;
     }
 
     toString () {
         return [
             this.spaces.before,
-            String('.' + this.value),
+            String('.' + this._valueFor("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/className.js
+++ b/src/selectors/className.js
@@ -29,9 +29,9 @@ export default class ClassName extends Node {
 
     toString () {
         return [
-            this.spaces.before,
+            this.rawSpaceBefore,
             String('.' + this.stringifyProperty("value")),
-            this.spaces.after,
+            this.rawSpaceAfter,
         ].join('');
     }
 }

--- a/src/selectors/className.js
+++ b/src/selectors/className.js
@@ -30,7 +30,7 @@ export default class ClassName extends Node {
     toString () {
         return [
             this.spaces.before,
-            String('.' + this._valueFor("value")),
+            String('.' + this.stringifyProperty("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/guards.js
+++ b/src/selectors/guards.js
@@ -67,5 +67,5 @@ export function isContainer (node) {
 }
 
 export function isNamespace (node) {
-    return isClassName(node) || isAttribute(node) || isTag(node);
+    return isAttribute(node) || isTag(node);
 }

--- a/src/selectors/id.js
+++ b/src/selectors/id.js
@@ -1,7 +1,7 @@
-import Namespace from './namespace';
+import Node from './node';
 import {ID as IDType} from './types';
 
-export default class ID extends Namespace {
+export default class ID extends Node {
     constructor (opts) {
         super(opts);
         this.type = IDType;
@@ -10,8 +10,7 @@ export default class ID extends Namespace {
     toString () {
         return [
             this.spaces.before,
-            this.ns,
-            String('#' + this.value),
+            String('#' + this.stringifyProperty("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/id.js
+++ b/src/selectors/id.js
@@ -9,9 +9,9 @@ export default class ID extends Node {
 
     toString () {
         return [
-            this.spaces.before,
+            this.rawSpaceBefore,
             String('#' + this.stringifyProperty("value")),
-            this.spaces.after,
+            this.rawSpaceAfter,
         ].join('');
     }
 }

--- a/src/selectors/namespace.js
+++ b/src/selectors/namespace.js
@@ -22,7 +22,7 @@ export default class Namespace extends Node {
 
     get namespaceString () {
         if (this.namespace) {
-            let ns = this.raws && this.raws.namespace || this.namespace;
+            let ns = this._valueFor("namespace");
             if (ns === true) {
                 return '';
             } else {

--- a/src/selectors/namespace.js
+++ b/src/selectors/namespace.js
@@ -1,3 +1,5 @@
+import cssesc from 'cssesc';
+import {ensureObject} from '../util';
 import Node from './node';
 
 export default class Namespace extends Node {
@@ -5,8 +7,20 @@ export default class Namespace extends Node {
         return this._namespace;
     }
     set namespace (namespace) {
+        if (namespace === true || namespace === "*" || namespace === "&") {
+            this._namespace = namespace;
+            if (this.raws) {
+                delete this.raws.namespace;
+            }
+            return;
+        }
+
+        let escaped = cssesc(namespace, {isIdentifier: true});
         this._namespace = namespace;
-        if (this.raws) {
+        if (escaped !== namespace) {
+            ensureObject(this, "raws");
+            this.raws.namespace = escaped;
+        } else if (this.raws) {
             delete this.raws.namespace;
         }
     }
@@ -14,10 +28,7 @@ export default class Namespace extends Node {
         return this._namespace;
     }
     set ns (namespace) {
-        this._namespace = namespace;
-        if (this.raws) {
-            delete this.raws.namespace;
-        }
+        this.namespace = namespace;
     }
 
     get namespaceString () {

--- a/src/selectors/namespace.js
+++ b/src/selectors/namespace.js
@@ -22,7 +22,7 @@ export default class Namespace extends Node {
 
     get namespaceString () {
         if (this.namespace) {
-            let ns = this._valueFor("namespace");
+            let ns = this.stringifyProperty("namespace");
             if (ns === true) {
                 return '';
             } else {

--- a/src/selectors/namespace.js
+++ b/src/selectors/namespace.js
@@ -43,9 +43,9 @@ export default class Namespace extends Node {
 
     toString () {
         return [
-            this.spaces.before,
+            this.rawSpaceBefore,
             this.qualifiedName(this.stringifyProperty("value")),
-            this.spaces.after,
+            this.rawSpaceAfter,
         ].join('');
     }
 };

--- a/src/selectors/namespace.js
+++ b/src/selectors/namespace.js
@@ -44,7 +44,7 @@ export default class Namespace extends Node {
     toString () {
         return [
             this.spaces.before,
-            this.qualifiedName(this.value),
+            this.qualifiedName(this.stringifyProperty("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -99,7 +99,7 @@ export default class Node {
      * characters to be directly inserted into css output.
      * @param {string} name the property to set
      * @param {any} value the unescaped value of the property
-     * @param {string} valueEscaped optional. the escaped value of the property.
+     * @param {string} valueEscaped the escaped value of the property.
      */
     setPropertyAndEscape (name, value, valueEscaped) {
         if (!this.raws) {

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -121,14 +121,14 @@ export default class Node {
         }
     }
 
-    _valueFor (name) {
+    stringifyProperty (name) {
         return (this.raws && this.raws[name]) || this[name];
     }
 
     toString () {
         return [
             this.spaces.before,
-            String(this._valueFor("value")),
+            String(this.stringifyProperty("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -26,7 +26,7 @@ let cloneNode = function (obj, parent) {
     return cloned;
 };
 
-export default class {
+export default class Node {
     constructor (opts = {}) {
         Object.assign(this, opts);
         this.spaces = this.spaces || {};

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -1,3 +1,5 @@
+import {ensureObject} from "../util";
+
 let cloneNode = function (obj, parent) {
     if (typeof obj !== 'object') {
         return obj;
@@ -125,11 +127,37 @@ export default class Node {
         return (this.raws && this.raws[name]) || this[name];
     }
 
+    get rawSpaceBefore () {
+        let rawSpace = this.raws && this.raws.spaces && this.raws.spaces.before;
+        if (rawSpace === undefined) {
+            rawSpace = this.spaces && this.spaces.before;
+        }
+        return rawSpace || "";
+    }
+
+    set rawSpaceBefore (raw) {
+        ensureObject(this, "raws", "spaces");
+        this.raws.spaces.before = raw;
+    }
+
+    get rawSpaceAfter () {
+        let rawSpace = this.raws && this.raws.spaces && this.raws.spaces.after;
+        if (rawSpace === undefined) {
+            rawSpace = this.spaces.after;
+        }
+        return rawSpace || "";
+    }
+
+    set rawSpaceAfter (raw) {
+        ensureObject(this, "raws", "spaces");
+        this.raws.spaces.after = raw;
+    }
+
     toString () {
         return [
-            this.spaces.before,
+            this.rawSpaceBefore,
             String(this.stringifyProperty("value")),
-            this.spaces.after,
+            this.rawSpaceAfter,
         ].join('');
     }
 }

--- a/src/selectors/node.js
+++ b/src/selectors/node.js
@@ -68,10 +68,67 @@ export default class Node {
         return cloned;
     }
 
+    /**
+     * Some non-standard syntax doesn't follow normal escaping rules for css.
+     * This allows non standard syntax to be appended to an existing property
+     * by specifying the escaped value. By specifying the escaped value,
+     * illegal characters are allowed to be directly inserted into css output.
+     * @param {string} name the property to set
+     * @param {any} value the unescaped value of the property
+     * @param {string} valueEscaped optional. the escaped value of the property.
+     */
+    appendToPropertyAndEscape (name, value, valueEscaped) {
+        if (!this.raws) {
+            this.raws = {};
+        }
+        let originalValue = this[name];
+        let originalEscaped = this.raws[name];
+        this[name] = originalValue + value; // this may trigger a setter that updates raws, so it has to be set first.
+        if (originalEscaped || valueEscaped !== value) {
+            this.raws[name] = (originalEscaped || originalValue) + valueEscaped;
+        } else {
+            delete this.raws[name]; // delete any escaped value that was created by the setter.
+        }
+    }
+
+    /**
+     * Some non-standard syntax doesn't follow normal escaping rules for css.
+     * This allows the escaped value to be specified directly, allowing illegal
+     * characters to be directly inserted into css output.
+     * @param {string} name the property to set
+     * @param {any} value the unescaped value of the property
+     * @param {string} valueEscaped optional. the escaped value of the property.
+     */
+    setPropertyAndEscape (name, value, valueEscaped) {
+        if (!this.raws) {
+            this.raws = {};
+        }
+        this[name] = value; // this may trigger a setter that updates raws, so it has to be set first.
+        this.raws[name] = valueEscaped;
+    }
+
+    /**
+     * When you want a value to passed through to CSS directly. This method
+     * deletes the corresponding raw value causing the stringifier to fallback
+     * to the unescaped value.
+     * @param {string} name the property to set.
+     * @param {any} value The value that is both escaped and unescaped.
+     */
+    setPropertyWithoutEscape (name, value) {
+        this[name] = value; // this may trigger a setter that updates raws, so it has to be set first.
+        if (this.raws) {
+            delete this.raws[name];
+        }
+    }
+
+    _valueFor (name) {
+        return (this.raws && this.raws[name]) || this[name];
+    }
+
     toString () {
         return [
             this.spaces.before,
-            String(this.value),
+            String(this._valueFor("value")),
             this.spaces.after,
         ].join('');
     }

--- a/src/selectors/pseudo.js
+++ b/src/selectors/pseudo.js
@@ -11,7 +11,7 @@ export default class Pseudo extends Container {
         let params = this.length ? '(' + this.map(String).join(',') + ')' : '';
         return [
             this.spaces.before,
-            String(this.value),
+            this.stringifyProperty("value"),
             params,
             this.spaces.after,
         ].join('');

--- a/src/selectors/pseudo.js
+++ b/src/selectors/pseudo.js
@@ -10,10 +10,10 @@ export default class Pseudo extends Container {
     toString () {
         let params = this.length ? '(' + this.map(String).join(',') + ')' : '';
         return [
-            this.spaces.before,
+            this.rawSpaceBefore,
             this.stringifyProperty("value"),
             params,
-            this.spaces.after,
+            this.rawSpaceAfter,
         ].join('');
     }
 }

--- a/src/selectors/root.js
+++ b/src/selectors/root.js
@@ -9,9 +9,9 @@ export default class Root extends Container {
 
     toString () {
         let str = this.reduce((memo, selector) => {
-            let sel = String(selector);
-            return sel ? memo + sel + ',' : '';
-        }, '').slice(0, -1);
+            memo.push(String(selector));
+            return memo;
+        }, []).join(',');
         return this.trailingComma ? str + ',' : str;
     }
 

--- a/src/tokenTypes.js
+++ b/src/tokenTypes.js
@@ -19,6 +19,7 @@ export const space            = ` `.charCodeAt(0);
 export const singleQuote      = `'`.charCodeAt(0);
 export const doubleQuote      = `"`.charCodeAt(0);
 export const slash            = `/`.charCodeAt(0);
+export const bang             = `!`.charCodeAt(0);
 
 export const backslash        = '\\'.charCodeAt(0);
 export const cr               = '\r'.charCodeAt(0);

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -93,6 +93,16 @@ function consumeEscape (css, start) {
     return next;
 }
 
+export const FIELDS = {
+    TYPE: 0,
+    START_LINE: 1,
+    START_COL: 2,
+    END_LINE: 3,
+    END_COL: 4,
+    START_POS: 5,
+    END_POS: 6,
+};
+
 export default function tokenize (input) {
     const tokens   = [];
     let css        = input.css.valueOf();

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -15,7 +15,6 @@ const wordDelimiters = {
 
     [t.ampersand]: true,
     [t.asterisk]: true,
-    [t.at]: true,
     [t.bang]: true,
     [t.comma]: true,
     [t.colon]: true,

--- a/src/util/ensureObject.js
+++ b/src/util/ensureObject.js
@@ -1,0 +1,11 @@
+export default function ensureObject (obj, ...props) {
+    while (props.length > 0) {
+        const prop = props.shift();
+
+        if (!obj[prop]) {
+            obj[prop] = {};
+        }
+
+        obj = obj[prop];
+    }
+}

--- a/src/util/getProp.js
+++ b/src/util/getProp.js
@@ -1,0 +1,13 @@
+export default function getProp (obj, ...props) {
+    while (props.length > 0) {
+        const prop = props.shift();
+
+        if (!obj[prop]) {
+            return undefined;
+        }
+
+        obj = obj[prop];
+    }
+
+    return obj;
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,3 @@
+export {default as unesc} from './unesc';
+export {default as getProp} from './getProp';
+export {default as ensureObject} from './ensureObject';

--- a/src/util/unesc.js
+++ b/src/util/unesc.js
@@ -1,0 +1,11 @@
+const HEX_ESC = /\\(?:([0-9a-fA-F]{6})|([0-9a-fA-F]{1,5}) )/g;
+const OTHER_ESC = /\\(.)/g;
+export default function unesc (str) {
+    str = str.replace(HEX_ESC, (_, hex1, hex2) => {
+        let hex = hex1 || hex2;
+        let code = parseInt(hex, 16);
+        return String.fromCharCode(code);
+    });
+    str = str.replace(OTHER_ESC, (_, char) => char);
+    return str;
+}

--- a/src/util/unesc.js
+++ b/src/util/unesc.js
@@ -1,4 +1,4 @@
-const HEX_ESC = /\\(?:([0-9a-fA-F]{6})|([0-9a-fA-F]{1,5}) )/g;
+const HEX_ESC = /\\(?:([0-9a-fA-F]{6})|([0-9a-fA-F]{1,5})(?: |(?![0-9a-fA-F])))/g;
 const OTHER_ESC = /\\(.)/g;
 export default function unesc (str) {
     str = str.replace(HEX_ESC, (_, hex1, hex2) => {


### PR DESCRIPTION
# Fix numerous escaping issues and syntax handling regressions in 3.0.

*Note: this PR is a Work-in-Progress. Feedback is welcome, commits are still forthcoming. Details will be added here as they develop.*

### TL;DR

Strings and identifiers from CSS files are now exposed to the API after unescaping them and API consumers going forward will set property values without containing any escape sequences. This optimizes the majority use-case of using standard CSS syntax and expecting it to Just Work™.

There are special APIs to use for setting values when normal CSS escaping rules are being intentionally broken -- these must be used whenever values are manipulating non-standard syntax. See methods `setPropertyWithoutEscape`, `setPropertyAndEscape`, and `appendToPropertyAndEscape` on the `Node` class.

**BREAKING CHANGES**: This PR introduces breaking changes. Where possible and likely to add the most value, deprecations have been added. But because it's impossible to know if a string has or hasn't been escaped by the caller, full deprecation handling is hard to achieve without materially making the new APIs worse and then introducing a subsequent deprecation/remove cycle back to the original API but with the new semantics. It's a lot of churn for API consumers, most of whom probably don't need to worry about whether things are escaped at all because they don't have a single escape in their stylesheets. For those users, this change appears as a bug fix (which indeed, it is).

## Gory Details

### Lexer

The lexer no longer breaks word tokens apart when an escape sequence is
encountered and word tokens starting with an escape continue past the first escape.

The lexer does not unescape. This allows the parser to capture the originally authored escape syntax and preserve it during stringification if a selector built from that token is left untouched.

### AST

Some AST nodes had support for a `raws` option that mirrors the primary values for the node but has the semantics that the value is already escaped and can be placed directly into the CSS file during stringification. Before this PR, the `raws` object was primarily used for capturing comments encountered mid-identifier and other corner-case issues. This PR normalizes this pattern and makes it available to all AST nodes so that the `raws` object is always considered during stringification. By default now, setters are used for node properties that can have values can contain characters that require escaping or that might change the escape behavior of other properties. Those setters keep the `raws` object up to date. Setting to the `raws` object does not affect the escaped value in any way, the methods mentioned above are provided to keep the two attributes in sync without having to set the raws object directly.

Constructors for all node types expect property values to be unescaped. If the `raws` value for a property containing characters requiring an escape is not provided, it will be initialized to the escaped value.

### Parser

The parser now sets properties to the escaped value and tracks the unescaped property values in `raws` for all node types with identifiers and strings.

### Notes for Specific Types of Nodes

#### `Node`

* `appendToPropertyAndEscape(name, value, valueEscaped)` - Adds to the existing value for the property named `name` for both the unescaped and escaped value. This is used by the parser in when tokens are encountered that should be included as part of the previous value. Some users may find it helpful as well, so it's public.
* `setPropertyAndEscape(name, value, valueEscaped)` - Set the property's value and the escaped value explicitly.
* `setPropertyWithoutEscape(name, value)` - Sets the property and the escape to the same value.
* `stringifyProperty(name)` - returns the string value for a property by reading from `raws` and falling back to the unescaped value.

#### `Attribute`

The biggest impact to this strategy is on the `Attribute` selector where
escapes are not uncommon in attribute names and quoted values are a type
of escape and in common use.

Because of this, there are some new APIs and conventions for `Attribute` specifically tailored around managing attribute values. Because these APIs are intended to remain, there are now deprecation warnings for ambiguous situations where it seems likely that the user is expecting the old semantics.

The `value` property now tracks the unescaped and unquoted (quotes are a type of escape sequence) value. This means that the selectors `[foo=bar]` and `[foo="bar"]` have the same `value` property. In this case, they will differ according to the value of `quoteMark` which can have the values of a single quote character, a double quote character and `null` for identifiers. Setting `value` property directly will continue to use the existing `quoteMark` for the attribute's value. Use the `setValue()` method to set the value while also managing the `quoteMark`. This method (and some others discussed later) now take options that allow for specifying a strategy for the quote mark depending on the options passed and the value being set. When `smart: true` is specified, the `quoteMark` will intelligently depend on the value being set. Depending on the `preferCurrentQuoteMark` option, the existing value for `quoteMark` can take precedence over the `quoteMark` provided in the options. Setting the `quoteMark` property directly will change the quote for an attribute's value and immediately synchronizes the `raws` value for the `value` property.

Additionally, the following new helper methods were added for `Attribute` nodes:

* `getQuotedValue(quoteMarkOpts)` - returns an escaped value that is quoted and escaped according to the quote mark options provided. If no options are passed, the existing quote mark value is used.
* `smartQuoteMark(quoteMarkOpts)` - returns the smart quote mark result for the current value, that can be assigned to `quoteMark` to convert it.
* `preferredQuoteMark(quoteMarkOpts)` - returns the preferred quote mark without considering the current value but after considering the options against the current value of `quoteMark`.

##### `ClassName`

`ClassName` used to inherit from `Namespace` but there's no legal CSS syntax for this and the string output with a namespace was just a simple concatenation. Furthermore, no tests failed when I changed the base class to `Node`. My assumption is that this was added to support some sort of future plans for non-standard syntax but that those plans never came to fruition. Removing it seems like the best way to make users tell me what the heck is going on there if they care about it 😅.