### PR TITLE
Update PostCSS to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8563,43 +8563,55 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
-      "integrity": "sha1-u6TVjohPx4yEDRU54Q7dqruPc70=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "source-map": "^0.5.6",
-        "supports-color": "^4.1.0"
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.0.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
+            "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "supports-color": "^5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
-          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.0.3",
     "minimist": "^1.2.0",
     "nyc": "^11.7.3",
-    "postcss": "^6.0.6",
+    "postcss": "^7.0.2",
     "semver": "^5.5.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
@chriseppstein, this is a dev dependency and does not impact tests.

---

If you are busy, may I publish an update as `v5.0.0-rc.3`? The publish would include these 2 fixes in since May:

- Ensure a token after a combinator https://github.com/postcss/postcss-selector-parser/commit/18ecae9ae1167ec55b6851ed468cb8b472086d80
- Allow comments after attribute insensitive flags (The case insensitive plugin would benefit from this change) https://github.com/postcss/postcss-selector-parser/commit/ccd499a1670dc24acd48fb0c79064c97dfbf33bd