### PR TITLE
fix: class selector with `\\#`

### DIFF
--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -49,3 +49,200 @@ test('escaped dot in class name', '.foo\\.bar', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, 'foo.bar');
     t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'foo\\.bar');
 });
+
+test('class selector with escaping', '.♥', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '♥');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (1)', '.©', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '©');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (2)', '.“‘’”', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '“‘’”');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (3)', '.☺☃', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '☺☃');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (4)', '.⌘⌥', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '⌘⌥');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (5)', '.𝄞♪♩♫♬', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '𝄞♪♩♫♬');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (5)', '.💩', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '💩');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+});
+
+test('class selector with escaping (6)', '.\\?', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '?');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\?');
+});
+
+test('class selector with escaping (7)', '.\\@', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '@');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\@');
+});
+
+test('class selector with escaping (8)', '.\\.', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '.');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\.');
+});
+
+test('class selector with escaping (9)', '.\\3A \\)', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, ':)');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\3A \\)');
+});
+
+test('class selector with escaping (10)', '.\\3A \\`\\(', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, ':`(');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\3A \\`\\(');
+});
+
+test('class selector with escaping (11)', '.\\31 23', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '123');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\31 23');
+});
+
+test('class selector with escaping (12)', '.\\31 a2b3c', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '1a2b3c');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\31 a2b3c');
+});
+
+test('class selector with escaping (13)', '.\\<p\\>', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '<p>');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\<p\\>');
+});
+
+test('class selector with escaping (14)', '.\\<\\>\\<\\<\\<\\>\\>\\<\\>', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '<><<<>><>');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\<\\>\\<\\<\\<\\>\\>\\<\\>');
+});
+
+test('class selector with escaping (15)', '.\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\[\\>\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\>\\+\\<\\<\\<\\<\\-\\]\\>\\+\\+\\.\\>\\+\\.\\+\\+\\+\\+\\+\\+\\+\\.\\.\\+\\+\\+\\.\\>\\+\\+\\.\\<\\<\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\.\\>\\.\\+\\+\\+\\.\\-\\-\\-\\-\\-\\-\\.\\-\\-\\-\\-\\-\\-\\-\\-\\.\\>\\+\\.\\>\\.', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\[\\>\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\>\\+\\<\\<\\<\\<\\-\\]\\>\\+\\+\\.\\>\\+\\.\\+\\+\\+\\+\\+\\+\\+\\.\\.\\+\\+\\+\\.\\>\\+\\+\\.\\<\\<\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\.\\>\\.\\+\\+\\+\\.\\-\\-\\-\\-\\-\\-\\.\\-\\-\\-\\-\\-\\-\\-\\-\\.\\>\\+\\.\\>\\.');
+});
+
+test('class selector with escaping (16)', '.\\#', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '#');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\#');
+});
+
+test('class selector with escaping (16)', '.\\#\\#', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '##');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\#\\#');
+});
+
+test('class selector with escaping (14)', '.\\#\\.\\#\\.\\#', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '#.#.#');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\#\\.\\#\\.\\#');
+});
+
+test('class selector with escaping (15)', '.\\_', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '_');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\_');
+});
+
+test('class selector with escaping (16)', '.\\{\\}', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '{}');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\{\\}');
+});
+
+test('class selector with escaping (17)', '.\\#fake\\-id', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '#fake-id');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\#fake\\-id');
+});
+
+test('class selector with escaping (18)', '.foo\\.bar', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo.bar');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'foo\\.bar');
+});
+
+test('class selector with escaping (19)', '.\\3A hover', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, ':hover');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\3A hover');
+});
+
+test('class selector with escaping (20)', '.\\3A hover\\3A focus\\3A active', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, ':hover:focus:active');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\3A hover\\3A focus\\3A active');
+});
+
+test('class selector with escaping (21)', '.\\[attr\\=value\\]', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '[attr=value]');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\[attr\\=value\\]');
+});
+
+test('class selector with escaping (22)', '.f\\/o\\/o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f/o/o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\/o\\/o');
+});
+
+test('class selector with escaping (23)', '.f\\\\o\\\\o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f\\o\\o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\\\o\\\\o');
+});
+
+test('class selector with escaping (24)', '.f\\*o\\*o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f*o*o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\*o\\*o');
+});
+
+test('class selector with escaping (25)', '.f\\!o\\!o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f!o!o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\!o\\!o');
+});
+
+test('class selector with escaping (26)', '.f\\\'o\\\'o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f\'o\'o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\\'o\\\'o');
+});
+
+test('class selector with escaping (27)', '.f\\~o\\~o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f~o~o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\~o\\~o');
+});
+
+test('class selector with escaping (28)', '.f\\+o\\+o', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'f+o+o');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'f\\+o\\+o');
+});

--- a/src/parser.js
+++ b/src/parser.js
@@ -822,7 +822,7 @@ export default class Parser {
             nextToken = this.nextToken;
         }
         const hasClass = indexesOf(word, '.').filter(i => word[i - 1] !== '\\');
-        let hasId = indexesOf(word, '#');
+        let hasId = indexesOf(word, '#').filter(i => word[i - 1] !== '\\');
         // Eliminate Sass interpolations from the list of id indexes
         const interpolations = indexesOf(word, '#{');
         if (interpolations.length) {


### PR DESCRIPTION
fixes #175 

Same fix as for previous PR (https://github.com/postcss/postcss-selector-parser/pull/178), so i added fix and tests

Based on https://mathiasbynens.be/demo/crazy-class