### PR TITLE
fix: do not create invalid combinator before comment

### DIFF
--- a/src/__tests__/comments.js
+++ b/src/__tests__/comments.js
@@ -38,3 +38,50 @@ test('ending in comment', ".bar /* comment 3 */", (t, tree) => {
     t.deepEqual(classname.spaces.after, ' ');
     t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */');
 });
+
+test('comments in selector list', 'h2, /*test*/ h4', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'tag');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'h2');
+    t.deepEqual(tree.nodes[1].nodes[0].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[1].nodes[0].type, 'comment');
+    t.deepEqual(tree.nodes[1].nodes[0].value, '/*test*/');
+    t.deepEqual(tree.nodes[1].nodes[1].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[1].nodes[1].type, 'tag');
+    t.deepEqual(tree.nodes[1].nodes[1].value, 'h4');
+});
+
+test('comments in selector list (2)', 'h2,/*test*/h4', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'tag');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'h2');
+    t.deepEqual(tree.nodes[1].nodes[0].rawSpaceBefore, '');
+    t.deepEqual(tree.nodes[1].nodes[0].type, 'comment');
+    t.deepEqual(tree.nodes[1].nodes[0].value, '/*test*/');
+    t.deepEqual(tree.nodes[1].nodes[1].type, 'tag');
+    t.deepEqual(tree.nodes[1].nodes[1].value, 'h4');
+    t.deepEqual(tree.nodes[1].nodes[1].rawSpaceBefore, '');
+});
+
+test('comments in selector list (3)', 'h2/*test*/, h4', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'tag');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'h2');
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceBefore, '');
+    t.deepEqual(tree.nodes[0].nodes[1].type, 'comment');
+    t.deepEqual(tree.nodes[0].nodes[1].value, '/*test*/');
+    t.deepEqual(tree.nodes[1].nodes[0].type, 'tag');
+    t.deepEqual(tree.nodes[1].nodes[0].value, 'h4');
+    t.deepEqual(tree.nodes[1].nodes[0].rawSpaceBefore, ' ');
+});
+
+test('comments in selector list (4)', 'h2, /*test*/ /*test*/ h4', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'tag');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'h2');
+    t.deepEqual(tree.nodes[1].nodes[0].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[1].nodes[0].type, 'comment');
+    t.deepEqual(tree.nodes[1].nodes[0].value, '/*test*/');
+    t.deepEqual(tree.nodes[1].nodes[1].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[1].nodes[1].type, 'comment');
+    t.deepEqual(tree.nodes[1].nodes[1].value, '/*test*/');
+    t.deepEqual(tree.nodes[1].nodes[2].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[1].nodes[2].type, 'tag');
+    t.deepEqual(tree.nodes[1].nodes[2].value, 'h4');
+});

--- a/src/parser.js
+++ b/src/parser.js
@@ -761,7 +761,8 @@ export default class Parser {
         if (
             this.position === 0 ||
             this.prevToken[TOKEN.TYPE] === tokens.comma ||
-            this.prevToken[TOKEN.TYPE] === tokens.openParenthesis
+            this.prevToken[TOKEN.TYPE] === tokens.openParenthesis ||
+            (this.current.nodes.every((node) => node.type === 'comment'))
         ) {
             this.spaces = this.optionalSpace(content);
             this.position ++;


### PR DESCRIPTION
Before:
```
h2, /*test*/ h4 -> type, comment combinator type
```
After:
```
h2, /*test*/ h4 -> type, comment, type
```