### PR TITLE
fix: parsing combinator after comment

### DIFF
--- a/src/__tests__/comments.js
+++ b/src/__tests__/comments.js
@@ -85,3 +85,29 @@ test('comments in selector list (4)', 'h2, /*test*/ /*test*/ h4', (t, tree) => {
     t.deepEqual(tree.nodes[1].nodes[2].type, 'tag');
     t.deepEqual(tree.nodes[1].nodes[2].value, 'h4');
 });
+
+test.only('comment before combinator', '.foo /**/ > .bar', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo');
+    // Need fix in next major release https://github.com/postcss/postcss-selector-parser/issues/189
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceBefore, ' /**/ ');
+    t.deepEqual(tree.nodes[0].nodes[1].type, 'combinator');
+    t.deepEqual(tree.nodes[0].nodes[1].value, '>');
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceAfter, ' ');
+    t.deepEqual(tree.nodes[0].nodes[2].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[2].value, 'bar');
+});
+
+test('comment after combinator', '.foo > /**/ .bar', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo');
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceBefore, ' ');
+    t.deepEqual(tree.nodes[0].nodes[1].type, 'combinator');
+    t.deepEqual(tree.nodes[0].nodes[1].value, '>');
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceAfter, ' ');
+    t.deepEqual(tree.nodes[0].nodes[2].type, 'comment');
+    t.deepEqual(tree.nodes[0].nodes[2].value, '/**/');
+    t.deepEqual(tree.nodes[0].nodes[1].rawSpaceAfter, ' ');
+    t.deepEqual(tree.nodes[0].nodes[3].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[3].value, 'bar');
+});

--- a/src/parser.js
+++ b/src/parser.js
@@ -507,8 +507,13 @@ export default class Parser {
         }
         // We need to decide between a space that's a descendant combinator and meaningless whitespace at the end of a selector.
         let nextSigTokenPos = this.locateNextMeaningfulToken(this.position);
+        let prevSigTokenPos = this.locatePrevMeaningfulToken();
 
-        if (nextSigTokenPos < 0 || this.tokens[nextSigTokenPos][TOKEN.TYPE] === tokens.comma) {
+        if (
+            nextSigTokenPos < 0 ||
+            this.tokens[nextSigTokenPos][TOKEN.TYPE] === tokens.comma ||
+            (prevSigTokenPos > 0 && this.tokens[prevSigTokenPos][TOKEN.TYPE] === tokens.combinator)
+        ) {
             let nodes = this.parseWhitespaceEquivalentTokens(nextSigTokenPos);
             if (nodes.length > 0) {
                 let last = this.current.last;
@@ -1025,6 +1030,23 @@ export default class Parser {
 
     get prevToken () {
         return this.tokens[this.position - 1];
+    }
+
+    /**
+     * returns the index of the previous non-whitespace, non-comment token.
+     * returns -1 if no meaningful token is found.
+     */
+    locatePrevMeaningfulToken (startPosition = this.position - 1) {
+        let searchPosition = startPosition;
+        while (searchPosition >= 0) {
+            if (WHITESPACE_EQUIV_TOKENS[this.tokens[searchPosition][TOKEN.TYPE]]) {
+                searchPosition--;
+                continue;
+            } else {
+                return searchPosition;
+            }
+        }
+        return -1;
     }
 
     /**


### PR DESCRIPTION
Before:
```
.foo > /**/ .bar {} /* [class, combinator, comment, combinator, class] */
```
After
```
.foo > /**/ .bar {} /* [class, combinator, comment, class] */
```