### PR TITLE
add escaped tests to classes

### DIFF
--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -252,3 +252,15 @@ test('class selector with escaping (34)', '.\\1D306', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
     t.deepEqual(tree.nodes[0].nodes[0].raws.value, '\\1D306');
 });
+
+test('class selector with escaping (35)', '.not-pseudo\\:focus', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'not-pseudo:focus');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'not-pseudo\\:focus');
+});
+
+test('class selector with escaping (36)', '.not-pseudo\\:\\:focus', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'not-pseudo::focus');
+    t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
+    t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'not-pseudo\\:\\:focus');
+});


### PR DESCRIPTION
Add some tests to understand that there is no problem in current version with escaping ':' , related to https://github.com/stylelint/stylelint/issues/3310