### PR TITLE
fix: replace node built-in "util" module with "util-deprecate"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7867,8 +7867,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "cssesc": "^3.0.0",
     "indexes-of": "^1.0.1",
-    "uniq": "^1.0.1"
+    "uniq": "^1.0.1",
+    "util-deprecate": "^1.0.2"
   },
   "license": "MIT",
   "engines": {

--- a/src/selectors/attribute.js
+++ b/src/selectors/attribute.js
@@ -3,7 +3,7 @@ import unesc from "../util/unesc";
 import Namespace from './namespace';
 import {ATTRIBUTE} from './types';
 
-const {deprecate} = require("util");
+const deprecate = require("util-deprecate");
 
 const WRAPPED_IN_QUOTES = /^('|")(.*)\1$/;
 


### PR DESCRIPTION
Using the Node built-in `util` module can causes errors or warnings when using bundlers such as Rollup, since the module only exists in Node, not the browser. (This may require the use of something like [rollup-plugin-node-builtins](https://github.com/calvinmetcalf/rollup-plugin-node-builtins).)

We only need `util` for the `util.deprecate()` function, so we can rely on [util-deprecate](https://github.com/TooTallNate/util-deprecate) instead, which simply wraps `util.deprecate()` in Node as well as providing a browser-based equivalent.