### PR TITLE
fix: TS2310 error 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
 install:
   - npm install -g npm@latest
   - npm ci
+  # https://github.com/microsoft/TypeScript/issues/40166
+  - |
+    if [ "$TRAVIS_NODE_VERSION" = '6' ]; then npm install typescript@3.9.7 ; fi
 script:
   - npm test
 cache:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7653,6 +7653,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7654,9 +7654,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "uid2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7654,9 +7654,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nyc": "^13.3.0",
     "postcss": "^7.0.14",
     "semver": "^5.6.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.3"
   },
   "main": "dist/index.js",
   "types": "postcss-selector-parser.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nyc": "^13.3.0",
     "postcss": "^7.0.14",
     "semver": "^5.6.0",
-    "typescript": "^4.0.3"
+    "typescript": "^3.9.7"
   },
   "main": "dist/index.js",
   "types": "postcss-selector-parser.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "minimist": "^1.2.0",
     "nyc": "^13.3.0",
     "postcss": "^7.0.14",
-    "semver": "^5.6.0"
+    "semver": "^5.6.0",
+    "typescript": "^4.0.3"
   },
   "main": "dist/index.js",
   "types": "postcss-selector-parser.d.ts",
@@ -31,7 +32,7 @@
     "postcss-selector-parser.d.ts"
   ],
   "scripts": {
-    "pretest": "eslint src",
+    "pretest": "eslint src && tsc --noEmit postcss-selector-parser.d.ts",
     "prepare": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "lintfix": "eslint --fix src",
     "report": "nyc report --reporter=html",

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -332,9 +332,10 @@ declare namespace parser {
     function root(opts: ContainerOptions): Root;
     function isRoot(node: any): node is Root;
 
-    interface Selector extends Container<string, Diff<Node, Selector>> {
+    interface _Selector<S> extends Container<string, Diff<Node, S>> {
         type: "selector";
     }
+    type Selector = _Selector<Selector>;
     function selector(opts: ContainerOptions): Selector;
     function isSelector(node: any): node is Selector;
 


### PR DESCRIPTION
This change aims to fix the following TypeScript error:

```
postcss-selector-parser.d.ts:335:15 - error TS2310: Type 'Selector' recursively references itself as a base type.
```

In addition, `npm run pretest` now checks the `.ts` file to detect such errors.

Fix #232