### PR TITLE
🚀 Rework unesc for a 63+% performance boost to all of postcss.

### DIFF
--- a/src/__tests__/classes.js
+++ b/src/__tests__/classes.js
@@ -264,3 +264,4 @@ test('class selector with escaping (36)', '.not-pseudo\\:\\:focus', (t, tree) =>
     t.deepEqual(tree.nodes[0].nodes[0].type, 'class');
     t.deepEqual(tree.nodes[0].nodes[0].raws.value, 'not-pseudo\\:\\:focus');
 });
+

--- a/src/__tests__/util/unesc.js
+++ b/src/__tests__/util/unesc.js
@@ -48,3 +48,15 @@ test('class selector with escaping with more chars', '.\\1D306k', (t, tree) => {
 test('class selector with escaping with more chars with whitespace', '.wow\\1D306 k', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, 'wow𝌆k');
 });
+
+test('handles 0 value hex', '\\0', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, String.fromCodePoint(0xFFFD));
+});
+
+test('handles lone surrogate value hex', '\\DBFF', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, String.fromCodePoint(0xFFFD));
+});
+
+test('handles out of bound values', '\\110000', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, String.fromCodePoint(0xFFFD));
+});

--- a/src/__tests__/util/unesc.js
+++ b/src/__tests__/util/unesc.js
@@ -1,0 +1,50 @@
+import {test} from '../util/helpers';
+
+test('id selector', '#foo', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo');
+});
+
+test('escaped special char', '#w\\+', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'w+');
+});
+
+test('tailing escape', '#foo\\', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'foo\\');
+});
+
+test('double escape', '#wow\\\\k', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'wow\\k');
+});
+
+test('leading numeric', '.\\31 23', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '123');
+});
+
+test('emoji', '.\\🐐', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '🐐');
+});
+
+// https://www.w3.org/International/questions/qa-escapes#cssescapes
+test('hex escape', '.\\E9motion', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'émotion');
+});
+
+test('hex escape with space', '.\\E9 dition', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'édition');
+});
+
+test('hex escape with hex number', '.\\0000E9dition', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'édition');
+});
+
+test('class selector with escaping', '.\\1D306', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '𝌆');
+});
+
+test('class selector with escaping with more chars', '.\\1D306k', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, '𝌆k');
+});
+
+test('class selector with escaping with more chars with whitespace', '.wow\\1D306 k', (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].value, 'wow𝌆k');
+});

--- a/src/util/unesc.js
+++ b/src/util/unesc.js
@@ -25,9 +25,18 @@ function gobbleHex (str) {
     if (hex.length === 0) {
         return undefined;
     }
+    const codePoint = parseInt(hex, 16);
+
+    const isSurrogate = codePoint >= 0xD800 && codePoint <= 0xDFFF;
+    // Add special case for
+    // "If this number is zero, or is for a surrogate, or is greater than the maximum allowed code point"
+    // https://drafts.csswg.org/css-syntax/#maximum-allowed-code-point
+    if (isSurrogate || codePoint === 0x0000 || codePoint > 0x10FFFF) {
+        return ['\uFFFD', hex.length + (spaceTerminated ? 1 : 0)];
+    }
 
     return [
-        String.fromCodePoint(parseInt(hex, 16)),
+        String.fromCodePoint(codePoint),
         hex.length + (spaceTerminated ? 1 : 0),
     ];
 }

--- a/src/util/unesc.js
+++ b/src/util/unesc.js
@@ -1,19 +1,73 @@
-const whitespace = '[\\x20\\t\\r\\n\\f]';
-const unescapeRegExp = new RegExp('\\\\([\\da-f]{1,6}' + whitespace + '?|(' + whitespace + ')|.)', 'ig');
+// Many thanks for this post which made this migration much easier.
+// https://mathiasbynens.be/notes/css-escapes
+
+/**
+ * 
+ * @param {string} str 
+ * @returns {[string, number]|undefined}
+ */
+function gobbleHex (str) {
+    const lower = str.toLowerCase();
+    let hex = '';
+    let spaceTerminated = false;
+    for (let i = 0; i < 6 && lower[i] !== undefined; i++) {
+        const code =  lower.charCodeAt(i);
+        // check to see if we are dealing with a valid hex char [a-f|0-9]
+        const valid = (code >= 97 && code <= 102) || (code >= 48 && code <= 57);
+        // https://drafts.csswg.org/css-syntax/#consume-escaped-code-point
+        spaceTerminated = code === 32;
+        if (!valid) {
+            break;
+        }
+        hex += lower[i];
+    }
+
+    if (hex.length === 0) {
+        return undefined;
+    }
+
+    return [
+        String.fromCodePoint(parseInt(hex, 16)),
+        hex.length + (spaceTerminated ? 1 : 0),
+    ];
+}
+
+const CONTAINS_ESCAPE = /\\/;
 
 export default function unesc (str) {
-    return str.replace(unescapeRegExp, (_, escaped, escapedWhitespace) => {
-        const high = '0x' + escaped - 0x10000;
+    let needToProcess = CONTAINS_ESCAPE.test(str);
+    if (!needToProcess) {
+        return str;
+    }
+    let ret = "";
 
-        // NaN means non-codepoint
-        // Workaround erroneous numeric interpretation of +"0x"
-        // eslint-disable-next-line no-self-compare
-        return high !== high || escapedWhitespace
-            ? escaped
-            : high < 0
-                ? // BMP codepoint
-                String.fromCharCode(high + 0x10000)
-                : // Supplemental Plane codepoint (surrogate pair)
-                String.fromCharCode((high >> 10) | 0xd800, (high & 0x3ff) | 0xdc00);
-    });
+    for (let i = 0; i < str.length; i++) {
+        if ((str[i] === "\\")) {
+            const gobbled = gobbleHex(str.slice(i + 1, i + 7));
+            if (gobbled !== undefined) {
+                ret += gobbled[0];
+                i += gobbled[1];
+                continue;
+            }
+
+            // Retain a pair of \\ if double escaped `\\\\`
+            // https://github.com/postcss/postcss-selector-parser/commit/268c9a7656fb53f543dc620aa5b73a30ec3ff20e
+            if (str[i + 1] === "\\") {
+                ret += "\\";
+                i++;
+                continue;
+            }
+
+            // if \\ is at the end of the string retain it
+            // https://github.com/postcss/postcss-selector-parser/commit/01a6b346e3612ce1ab20219acc26abdc259ccefb
+            if (str.length === i + 1) {
+                ret += str[i];
+            }
+            continue;
+        }
+      
+        ret += str[i];
+    }
+
+    return ret;
 }


### PR DESCRIPTION
In profiling postcss I found that a significant amount of time was being
spent in [`unesc`](https://github.com/postcss/postcss-selector-parser/commits/master/src/util/unesc.js), this was due to the expensive regex checks that were
being performed on the fly for every selector in the codebase which looked to be performing quite poorly inside of modern node and v8.

## Old

![image](https://user-images.githubusercontent.com/883126/114136698-fdd98a80-98bf-11eb-8068-ace4f6f2274d.png)

----

As an experiment and based on some prior experience with this class of slowdown I migrated the implementation to one that performs a scan through the string instead of running a regex replace. By testing this on my local application I instantly saw the work from this function go from > 900 ms to ~100ms.

## New

![image](https://user-images.githubusercontent.com/883126/114136734-0c27a680-98c0-11eb-82ab-f0c9529fd32d.png)

This implementation passes all of the existing test cases and aims to mirror the prior implementation's implementation details :)

-----

Based on my application I am seeing the major wins come from purgecss dropping my total application build by multiple seconds! 🔥 

---------

## Perf testing

I set up a simple perf test here:
https://github.com/samccone/postcss-selector-parser/commit/be99c239a394327c7788abfbccc021821f26a0bf which takes all of tailwind's css selectors and then unescapes them 100 times.

(left old, right new) 
![image](https://user-images.githubusercontent.com/883126/114244725-dfb56e00-9943-11eb-92ce-38b229fdc217.png)


__Previously this simple test took **20.17ms** now it takes **7.1ms** -- a 63% difference__ 



Finally based on input I did a comparison between the new, old, and chrome's implementation for this work

```
original 
        avg: 4.765ms
        std: 2.5159ms
        max: 35ms
        min: 3ms
        
new 
        avg: 1.76ms
        std: 0.7915ms
        max: 12ms
        min: 1ms
        
chrome 
        avg: 4.383ms
        std: 1.7602ms
        max: 34ms
        min: 3ms
```

You can run the test case here https://github.com/samccone/postcss-selector-parser/blob/sjs/perf/perf/index.js, the testing is similar to what I did before but now I run the test cases 1000 times each.


Finally I tested this on tailwind and saw the wins propagating to the ecosystem with this patch!
https://twitter.com/samccone/status/1381423236253032454