### PR TITLE
Fix source indices for Sass interpolated selectors

### DIFF
--- a/src/__tests__/nonstandard.js
+++ b/src/__tests__/nonstandard.js
@@ -69,6 +69,15 @@ test('sass escapes (3)', '.classname1.#{$classname2}', (t, tree) => {
     t.deepEqual(node2.sourceIndex, 11);
 });
 
+test('Sass escapes (4)', `.#{classname1}\\ classname2`, (t, tree) => {
+    const node = tree.nodes[0].nodes[0];
+    t.deepEqual(node.type, "class");
+    t.deepEqual(node.value, "#{classname1} classname2");
+    t.deepEqual(node.source.start.column, 1);
+    t.deepEqual(node.source.end.column, 26);
+    t.deepEqual(node.sourceIndex, 0);
+});
+
 test('placeholder', '%foo', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, "tag");
     t.deepEqual(tree.nodes[0].nodes[0].value, "%foo");

--- a/src/__tests__/nonstandard.js
+++ b/src/__tests__/nonstandard.js
@@ -4,14 +4,32 @@ test('non-standard selector', '.icon.is-$(network)', (t, tree) => {
     let class1 = tree.nodes[0].nodes[0];
     t.deepEqual(class1.value, 'icon');
     t.deepEqual(class1.type, 'class');
+    t.deepEqual(class1.source.start.column, 1);
+    t.deepEqual(class1.source.end.column, 5);
+    t.deepEqual(class1.sourceIndex, 0);
+
     let class2 = tree.nodes[0].nodes[1];
     t.deepEqual(class2.value, 'is-$(network)');
     t.deepEqual(class2.type, 'class');
+    t.deepEqual(class2.source.start.column, 6);
+    // t.deepEqual(class2.source.end.column, 19); // Fail - 10
+    t.deepEqual(class2.sourceIndex, 5);
 });
 
 test('at word in selector', 'em@il.com', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].value, 'em@il');
-    t.deepEqual(tree.nodes[0].nodes[1].value, 'com');
+    const node1 = tree.nodes[0].nodes[0];
+    t.deepEqual(node1.value, 'em@il');
+    t.deepEqual(node1.type, 'tag');
+    t.deepEqual(node1.source.start.column, 1);
+    t.deepEqual(node1.source.end.column, 5);
+    t.deepEqual(node1.sourceIndex, 0);
+
+    const node2 = tree.nodes[0].nodes[1];
+    t.deepEqual(node2.value, 'com');
+    t.deepEqual(node2.type, 'class');
+    t.deepEqual(node2.source.start.column, 6);
+    t.deepEqual(node2.source.end.column, 9);
+    t.deepEqual(node2.sourceIndex, 5);
 });
 
 test('leading combinator', '> *', (t, tree) => {
@@ -20,8 +38,12 @@ test('leading combinator', '> *', (t, tree) => {
 });
 
 test('sass escapes', '.#{$classname}', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].type, "class");
-    t.deepEqual(tree.nodes[0].nodes[0].value, "#{$classname}");
+    const node = tree.nodes[0].nodes[0];
+    t.deepEqual(node.type, "class");
+    t.deepEqual(node.value, "#{$classname}");
+    t.deepEqual(node.source.start.column, 1);
+    t.deepEqual(node.source.end.column, 14);
+    t.deepEqual(node.sourceIndex, 0);
 });
 
 test('sass escapes (2)', '[lang=#{$locale}]', (t, tree) => {
@@ -31,14 +53,34 @@ test('sass escapes (2)', '[lang=#{$locale}]', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].value, "#{$locale}");
 });
 
+test('sass escapes (3)', '.classname1.#{$classname2}', (t, tree) => {
+    const node1 = tree.nodes[0].nodes[0];
+    t.deepEqual(node1.type, "class");
+    t.deepEqual(node1.value, "classname1");
+    t.deepEqual(node1.source.start.column, 1);
+    t.deepEqual(node1.source.end.column, 11);
+    t.deepEqual(node1.sourceIndex, 0);
+
+    const node2 = tree.nodes[0].nodes[1];
+    t.deepEqual(node2.type, "class");
+    t.deepEqual(node2.value, "#{$classname2}");
+    t.deepEqual(node2.source.start.column, 12);
+    t.deepEqual(node2.source.end.column, 26);
+    t.deepEqual(node2.sourceIndex, 11);
+});
+
 test('placeholder', '%foo', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].type, "tag");
     t.deepEqual(tree.nodes[0].nodes[0].value, "%foo");
 });
 
 test('styled selector', '${Step}', (t, tree) => {
-    t.deepEqual(tree.nodes[0].nodes[0].type, "tag");
-    t.deepEqual(tree.nodes[0].nodes[0].value, "${Step}");
+    const node = tree.nodes[0].nodes[0];
+    t.deepEqual(node.type, "tag");
+    t.deepEqual(node.value, "${Step}");
+    t.deepEqual(node.source.start.column, 1);
+    t.deepEqual(node.source.end.column, 7);
+    t.deepEqual(node.sourceIndex, 0);
 });
 
 test('styled selector (2)', '${Step}:nth-child(odd)', (t, tree) => {

--- a/src/__tests__/nonstandard.js
+++ b/src/__tests__/nonstandard.js
@@ -69,12 +69,12 @@ test('sass escapes (3)', '.classname1.#{$classname2}', (t, tree) => {
     t.deepEqual(node2.sourceIndex, 11);
 });
 
-test('Sass escapes (4)', `.#{classname1}\\ classname2`, (t, tree) => {
+test('Sass escapes (4)', `.#{$classname1}\\$classname2`, (t, tree) => {
     const node = tree.nodes[0].nodes[0];
     t.deepEqual(node.type, "class");
-    t.deepEqual(node.value, "#{classname1} classname2");
+    t.deepEqual(node.value, "#{$classname1}$classname2");
     t.deepEqual(node.source.start.column, 1);
-    t.deepEqual(node.source.end.column, 26);
+    t.deepEqual(node.source.end.column, 27);
     t.deepEqual(node.sourceIndex, 0);
 });
 

--- a/src/sortAscending.js
+++ b/src/sortAscending.js
@@ -1,3 +1,0 @@
-export default function sortAscending (list) {
-    return list.sort((a, b) => a - b);
-};


### PR DESCRIPTION
Fixes https://github.com/postcss/postcss-selector-parser/issues/243

I had to rewrite most of the `splitWords` parser method because the previous one didn't use the correct indices when multiple tokens were involved.
