### PR TITLE
fix: `Combinator.raws` property type

### DIFF
--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -339,8 +339,16 @@ declare namespace parser {
     function selector(opts: ContainerOptions): Selector;
     function isSelector(node: any): node is Selector;
 
+    interface CombinatorRaws {
+        value?: string;
+        spaces?: {
+            before?: string;
+            after?: string;
+        };
+    }
     interface Combinator extends Base {
-        type: "combinator"
+        type: "combinator";
+        raws?: CombinatorRaws;
     }
     function combinator(opts: NodeOptions): Combinator;
     function isCombinator(node: any): node is Combinator;


### PR DESCRIPTION
Fix #253

I fixed the `Combinator` type by referencing `src/parser.js`. Please let me know if there are any problems.

https://github.com/postcss/postcss-selector-parser/blob/210fd21e397b03ab48b6a02090bc01d17a8749ed/src/parser.js#L500

https://github.com/postcss/postcss-selector-parser/blob/210fd21e397b03ab48b6a02090bc01d17a8749ed/src/parser.js#L552

https://github.com/postcss/postcss-selector-parser/blob/210fd21e397b03ab48b6a02090bc01d17a8749ed/src/parser.js#L587