### PR TITLE
fix: `isPseudoElement()` supports `:first-letter` and `:first-line`

### DIFF
--- a/src/__tests__/guards.js
+++ b/src/__tests__/guards.js
@@ -79,8 +79,8 @@ test('pseudo element guard', '::first-line', (t, tree) => {
     t.false(parser.isNamespace(n));
 });
 
-test('special pseudo element guard', ':before:after', (t, tree) => {
-    [node(tree), node(tree, 1)].forEach((n) => {
+test('special pseudo element guard', ':before:after:first-letter:first-line', (t, tree) => {
+    [node(tree), node(tree, 1), node(tree, 2), node(tree, 3)].forEach((n) => {
         t.true(parser.isPseudo(n));
         t.false(parser.isPseudoClass(n));
         t.true(parser.isPseudoElement(n));
@@ -89,8 +89,8 @@ test('special pseudo element guard', ':before:after', (t, tree) => {
     });
 });
 
-test('special pseudo element guard (uppercase)', ':BEFORE:AFTER', (t, tree) => {
-    [node(tree), node(tree, 1)].forEach((n) => {
+test('special pseudo element guard (uppercase)', ':BEFORE:AFTER:FIRST-LETTER:FIRST-LINE', (t, tree) => {
+    [node(tree), node(tree, 1), node(tree, 2), node(tree, 3)].forEach((n) => {
         t.true(parser.isPseudo(n));
         t.false(parser.isPseudoClass(n));
         t.true(parser.isPseudoElement(n));

--- a/src/selectors/guards.js
+++ b/src/selectors/guards.js
@@ -56,6 +56,8 @@ export function isPseudoElement (node) {
                node.value.startsWith("::")
              || node.value.toLowerCase() === ":before"
              || node.value.toLowerCase() === ":after"
+             || node.value.toLowerCase() === ":first-letter"
+             || node.value.toLowerCase() === ":first-line"
            );
 }
 export function isPseudoClass (node) {


### PR DESCRIPTION
Browsers supports also `:first-letter` and `:first-line` pseudo-elements introduced in CSS2.

- https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter
- https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line