### PR TITLE
throw on unexpected pipe symbols

### DIFF
--- a/src/__tests__/namespaces.mjs
+++ b/src/__tests__/namespaces.mjs
@@ -1,4 +1,4 @@
-import {test} from './util/helpers.mjs';
+import {test, throws} from './util/helpers.mjs';
 
 test('match tags in the postcss namespace', 'postcss|button', (t, tree) => {
     t.deepEqual(tree.nodes[0].nodes[0].namespace, 'postcss');
@@ -76,3 +76,10 @@ test('ns alias for namespace', 'f\\oo|h1.foo', (t, tree) => {
     t.deepEqual(tag.namespace, 'bar');
     t.deepEqual(tag.ns, 'bar');
 });
+
+throws('lone pipe symbol', '|');
+throws('lone pipe symbol with leading spaces', ' |');
+throws('lone pipe symbol with trailing spaces', '| ');
+throws('lone pipe symbol with surrounding spaces', ' | ');
+throws('trailing pipe symbol with a namespace', 'foo| ');
+throws('trailing pipe symbol with any namespace', '*| ');

--- a/src/parser.js
+++ b/src/parser.js
@@ -646,6 +646,10 @@ export default class Parser {
         return this.error(`Unexpected '${this.content()}'. Escaping special characters with \\ may help.`, this.currToken[TOKEN.START_POS]);
     }
 
+    unexpectedPipe () {
+        return this.error(`Unexpected '|'.`, this.currToken[TOKEN.START_POS]);
+    }
+
     namespace () {
         const before = this.prevToken && this.content(this.prevToken) || true;
         if (this.nextToken[TOKEN.TYPE] === tokens.word) {
@@ -655,6 +659,8 @@ export default class Parser {
             this.position ++;
             return this.universal(before);
         }
+
+        this.unexpectedPipe();
     }
 
     nesting () {


### PR DESCRIPTION
fixes : https://github.com/postcss/postcss-selector-parser/issues/266

spec ref : https://drafts.csswg.org/selectors/#type-nmsp