### PR TITLE
Fix `Node#prev` and `Node#next` type for the first/last node

### DIFF
--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -164,8 +164,8 @@ declare namespace parser {
         rawSpaceAfter: string;
         remove(): Node;
         replaceWith(...nodes: Node[]): Node;
-        next(): Node;
-        prev(): Node;
+        next(): Node | undefined;
+        prev(): Node | undefined;
         clone(opts?: {[override: string]:any}): this;
         /**
          * Return whether this node includes the character at the position of the given line and column.


### PR DESCRIPTION
I think we should have `undefined` here as well, because on first/last node it should return `undefined`