### PR TITLE
fix(types): add missing `index` argument to `each`/`walk` callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "!**/__tests__"
   ],
   "scripts": {
-    "pretest": "eslint src && tsc --noEmit postcss-selector-parser.d.ts",
+    "typecheck": "tsc --noEmit --strict postcss-selector-parser.d.ts postcss-selector-parser.test.ts",
+    "pretest": "eslint src && npm run typecheck",
     "prepare": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "lintfix": "eslint --fix src",
     "report": "nyc report --reporter=html",

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -237,9 +237,9 @@ declare namespace parser {
         empty(): this;
         insertAfter(oldNode: Child, newNode: Child): this;
         insertBefore(oldNode: Child, newNode: Child): this;
-        each(callback: (node: Child) => boolean | void): boolean | undefined;
+        each(callback: (node: Child, index: number) => boolean | void): boolean | undefined;
         walk(
-            callback: (node: Node) => boolean | void
+            callback: (node: Node, index: number) => boolean | void
         ): boolean | undefined;
         walkAttributes(
             callback: (node: Attribute) => boolean | void

--- a/postcss-selector-parser.test.ts
+++ b/postcss-selector-parser.test.ts
@@ -1,0 +1,12 @@
+import * as parser from './postcss-selector-parser';
+
+parser((root) => {
+    root.each((node, index) => {
+        node as parser.Selector;
+        index as number;
+    });
+    root.walk((node, index) => {
+        node as parser.Selector;
+        index as number;
+    });
+}).processSync("a b > c");

--- a/src/__tests__/container.mjs
+++ b/src/__tests__/container.mjs
@@ -22,14 +22,17 @@ test('container#prepend', (t) => {
 
 test('container#each', (t) => {
     let str = '';
+    let indexes = [];
     parse('h1, h2:not(h3, h4)', (selectors) => {
-        selectors.each((selector) => {
+        selectors.each((selector, index) => {
             if (selector.first.type === 'tag') {
                 str += selector.first.value;
             }
+            indexes.push(index);
         });
     });
     t.deepEqual(str, 'h1h2');
+    t.deepEqual(indexes, [0, 1]);
 });
 
 test('container#each (safe iteration)', (t) => {
@@ -63,14 +66,17 @@ test('container#each (early exit)', (t) => {
 
 test('container#walk', (t) => {
     let str = '';
+    let indexes = [];
     parse('h1, h2:not(h3, h4)', (selectors) => {
-        selectors.walk((selector) => {
+        selectors.walk((selector, index) => {
             if (selector.type === 'tag') {
                 str += selector.value;
+                indexes.push(index);
             }
         });
     });
     t.deepEqual(str, 'h1h2h3h4');
+    t.deepEqual(indexes, [0, 0, 0, 0]);
 });
 
 test('container#walk (safe iteration)', (t) => {


### PR DESCRIPTION
`container.each(callback)` and `container.walk(callback)` support the second argument `index` in the `callback` function, but the argument is not reflected on the type definitions.

See the API document:
- `each`: https://github.com/postcss/postcss-selector-parser/blob/3c072b84259b1966fda4823ee7f7228cabe2a164/API.md?plain=1#L462-L463
- `walk`: https://github.com/postcss/postcss-selector-parser/blob/3c072b84259b1966fda4823ee7f7228cabe2a164/API.md?plain=1#L478-L479

Closes #249