### PR TITLE
improve typings of constructor helpers

### DIFF
--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -532,13 +532,13 @@ declare namespace parser {
     interface Identifier extends Base {
         type: "id";
     }
-    function id(opts: any): any;
+    function id(opts: any): Identifier;
     function isIdentifier(node: any): node is Identifier;
 
     interface Nesting extends Base {
         type: "nesting";
     }
-    function nesting(opts: any): any;
+    function nesting(opts: any): Nesting;
     function isNesting(node: any): node is Nesting;
 
     interface String extends Base {
@@ -550,6 +550,6 @@ declare namespace parser {
     interface Universal extends Base {
         type: "universal";
     }
-    function universal(opts?: NamespaceOptions): any;
+    function universal(opts?: NamespaceOptions): Universal;
     function isUniversal(node: any): node is Universal;
 }

--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -538,7 +538,7 @@ declare namespace parser {
     interface Nesting extends Base {
         type: "nesting";
     }
-    function nesting(opts: any): Nesting;
+    function nesting(opts?: any): Nesting;
     function isNesting(node: any): node is Nesting;
 
     interface String extends Base {

--- a/src/__tests__/constructors.mjs
+++ b/src/__tests__/constructors.mjs
@@ -1,0 +1,7 @@
+import test from 'ava';
+import parser from '../index.js';
+
+test('constructors#nesting', (t) => {
+    t.deepEqual(parser.nesting().toString(), '&');
+    t.deepEqual(parser.nesting({}).toString(), '&');
+});


### PR DESCRIPTION
All of the constructor helpers always return an instance, the actual type of the returned value is always known.