### PR TITLE
docs: section link Error Handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -786,7 +786,7 @@ has a method `error(message, options)` that returns an
 error object. This method should always be used to raise
 errors relating to the syntax of selectors. The options
 to this method are passed to postcss's error constructor
-([documentation](http://api.postcss.org/Container.html#error)).
+([documentation](http://postcss.org/api/#container-error)).
 
 #### Async Error Example
 


### PR DESCRIPTION
Recent link to access intended section of the page.