### PR TITLE
fix erroneous trailing combinators in pseudos

### DIFF
--- a/src/__tests__/comments.mjs
+++ b/src/__tests__/comments.mjs
@@ -33,10 +33,35 @@ test('multiple comments and other things', 'h1/*test*/h2/*test*/.test/*test*/', 
 });
 
 test('ending in comment', ".bar /* comment 3 */", (t, tree) => {
+    t.is(tree.nodes[0].nodes.length, 1);
     let classname = tree.nodes[0].nodes[0];
     t.deepEqual(classname.type, 'class', 'should have a tag');
     t.deepEqual(classname.spaces.after, ' ');
     t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */');
+});
+
+test('ending in comment and whitespace', ".bar /* comment 3 */ ", (t, tree) => {
+    t.is(tree.nodes[0].nodes.length, 1);
+    let classname = tree.nodes[0].nodes[0];
+    t.deepEqual(classname.type, 'class', 'should have a tag');
+    t.deepEqual(classname.spaces.after, '  ');
+    t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */ ');
+});
+
+test('ending in comment in a pseudo', ":is(.bar /* comment 3 */)", (t, tree) => {
+    t.is(tree.nodes[0].nodes[0].nodes[0].nodes.length, 1);
+    let classname = tree.nodes[0].nodes[0].nodes[0].nodes[0];
+    t.deepEqual(classname.type, 'class', 'should have a tag');
+    t.deepEqual(classname.spaces.after, ' ');
+    t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */');
+});
+
+test('ending in comment and whitespace in a pseudo', ":is(.bar /* comment 3 */ )", (t, tree) => {
+    t.is(tree.nodes[0].nodes[0].nodes[0].nodes.length, 1);
+    let classname = tree.nodes[0].nodes[0].nodes[0].nodes[0];
+    t.deepEqual(classname.type, 'class', 'should have a tag');
+    t.deepEqual(classname.spaces.after, '  ');
+    t.deepEqual(classname.raws.spaces.after, ' /* comment 3 */ ');
 });
 
 test('comments in selector list', 'h2, /*test*/ h4', (t, tree) => {

--- a/src/parser.js
+++ b/src/parser.js
@@ -525,7 +525,7 @@ export default class Parser {
         // We need to decide between a space that's a descendant combinator and meaningless whitespace at the end of a selector.
         let nextSigTokenPos = this.locateNextMeaningfulToken(this.position);
 
-        if (nextSigTokenPos < 0 || this.tokens[nextSigTokenPos][TOKEN.TYPE] === tokens.comma) {
+        if (nextSigTokenPos < 0 || this.tokens[nextSigTokenPos][TOKEN.TYPE] === tokens.comma || this.tokens[nextSigTokenPos][TOKEN.TYPE] === tokens.closeParenthesis) {
             let nodes = this.parseWhitespaceEquivalentTokens(nextSigTokenPos);
             if (nodes.length > 0) {
                 let last = this.current.last;


### PR DESCRIPTION
`:is(.bar /* comment 3 */ )` would produce: `TAG COMBINATOR` inside the `:is()`.
While the ` /* comment 3 */ ` is actually just meaningless whitespace and comments.

Adding `)` to the list of tokens when checking for the end of a selector fixes this issue