### PR TITLE
fix: typo

### DIFF
--- a/postcss-selector-parser.d.ts
+++ b/postcss-selector-parser.d.ts
@@ -86,12 +86,12 @@ declare namespace parser {
 
     interface Options {
         /**
-         * Preserve whitespace when true. Default: false;
+         * Preserve whitespace when true. Default: true;
          */
         lossless: boolean;
         /**
          * When true and a postcss.Rule is passed, set the result of
-         * processing back onto the rule when done. Default: false.
+         * processing back onto the rule when done. Default: true.
          */
         updateSelector: boolean;
     }


### PR DESCRIPTION
Fixed incorrect default value comments in the `Options` interface.

See: https://github.com/postcss/postcss-selector-parser/blob/6158750aab0aed3046a5920bd58e0e0266a4ada2/API.md#processoroptions

https://github.com/postcss/postcss-selector-parser/blob/6158750aab0aed3046a5920bd58e0e0266a4ada2/src/processor.js#L10-L26