### PR TITLE
perf: replace startsWith with strict equality

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -581,7 +581,7 @@ export default class Parser {
             if (space.endsWith(' ') && rawSpace.endsWith(' ')) {
                 spaces.before = space.slice(0, space.length - 1);
                 raws.spaces.before = rawSpace.slice(0, rawSpace.length - 1);
-            } else if (space.startsWith(' ') && rawSpace.startsWith(' ')) {
+            } else if (space[0] === ' ' && rawSpace[0] === ' ') {
                 spaces.after = space.slice(1);
                 raws.spaces.after = rawSpace.slice(1);
             } else {


### PR DESCRIPTION
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)