### PR TITLE
fix: don't treat a non-prefix token before `|` as a namespace

### DIFF
--- a/src/__tests__/namespaces.mjs
+++ b/src/__tests__/namespaces.mjs
@@ -77,6 +77,21 @@ test("ns alias for namespace", "f\\oo|h1.foo", (t, tree) => {
   t.deepEqual(tag.ns, "bar");
 });
 
+test("empty namespace after a comment is not a prefix", "/* c */|b", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[1].namespace, true);
+  t.deepEqual(tree.nodes[0].nodes[1].value, "b");
+});
+
+test("empty namespace after a comma is not a prefix", ".a,|b", (t, tree) => {
+  t.deepEqual(tree.nodes[1].nodes[0].namespace, true);
+  t.deepEqual(tree.nodes[1].nodes[0].value, "b");
+});
+
+test("empty namespace after a combinator is not a prefix", ".a > |b", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[2].namespace, true);
+  t.deepEqual(tree.nodes[0].nodes[2].value, "b");
+});
+
 throws("lone pipe symbol", "|");
 throws("lone pipe symbol with leading spaces", " |");
 throws("lone pipe symbol with trailing spaces", "| ");

--- a/src/parser.js
+++ b/src/parser.js
@@ -696,7 +696,17 @@ export default class Parser {
   }
 
   namespace() {
-    const before = (this.prevToken && this.content(this.prevToken)) || true;
+    const prev = this.prevToken;
+    // Only treat the previous token as a namespace prefix when it can actually
+    // be one (a type/word or the universal `*`). A comment, comma, combinator
+    // or whitespace before `|` means an empty namespace, not a prefix.
+    const before =
+      prev &&
+      (prev[TOKEN.TYPE] === tokens.word ||
+        prev[TOKEN.TYPE] === tokens.asterisk ||
+        prev[TOKEN.TYPE] === tokens.ampersand)
+        ? this.content(prev)
+        : true;
     if (this.nextToken[TOKEN.TYPE] === tokens.word) {
       this.position++;
       return this.word(before);


### PR DESCRIPTION
## Problem

When a bare `|` introduces an empty namespace, whatever token precedes it is emitted as the namespace prefix — corrupting the selector on a round-trip:

```js
const parser = require("postcss-selector-parser");
const rt = (s) => { let o; parser((r) => (o = r.toString())).processSync(s); return o; };

rt("/* c */|b"); // "/* c */\/\*\ c\ \*\/|b"   — the comment is re-emitted, escaped, as a prefix
rt(".a,|b");     // ".a,\,|b"                    — the comma becomes an escaped prefix
rt(".a > |b");   // ".a >  |b"                   — extra whitespace
rt(" |b");       // "  |b"
```

These are all valid selectors that should round-trip unchanged.

## Root cause

`namespace()` takes the prefix from the previous token unconditionally:

```js
namespace() {
  const before = (this.prevToken && this.content(this.prevToken)) || true;
  …
}
```

`namespace()` is reached either after a real prefix has been consumed (`*|`, `ns|`, `&|`, where the previous token is that prefix) or directly from `combinator()` when a bare `|` starts a compound. In the second case the previous token is a comment, comma, combinator or whitespace — not a prefix — but it was still used as one.

## Fix

Only use the previous token as the prefix when it can actually be one — a word (type selector), the universal `*`, or the nesting `&` (these are exactly the tokens whose parsing hands off to `namespace()`). Otherwise the namespace is empty (`true`).

```js
const prev = this.prevToken;
const before =
  prev &&
  (prev[TOKEN.TYPE] === tokens.word ||
    prev[TOKEN.TYPE] === tokens.asterisk ||
    prev[TOKEN.TYPE] === tokens.ampersand)
    ? this.content(prev)
    : true;
```

`*|a`, `ns|a`, `&|foo`, and `|a` are unchanged.

## Test plan

- Added tests for an empty namespace after a comment, a comma, and a combinator (they fail on `main`).
- A round-trip property check over generated selectors flagged exactly these cases; the fix clears them with no regressions. Full suite green (783), `eslint`/`tsc` clean.
