### PR TITLE
fix: preserve whitespace before a `*` namespace in attribute selectors

### DIFF
--- a/src/__tests__/attributes.mjs
+++ b/src/__tests__/attributes.mjs
@@ -28,6 +28,13 @@ test("attribute selector spaces with namespace (both)", "[  foo|bar   ]", (t, tr
   t.deepEqual(tree.nodes[0].nodes[0].type, "attribute");
   t.falsy(tree.nodes[0].nodes[0].quoted);
 });
+test("attribute selector spaces with universal namespace (both)", "[  *|bar   ]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "*");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "bar");
+  t.deepEqual(tree.nodes[0].nodes[0].spaces.attribute.before, "  ");
+  t.deepEqual(tree.nodes[0].nodes[0].spaces.attribute.after, "   ");
+  t.deepEqual(tree.nodes[0].nodes[0].type, "attribute");
+});
 test("attribute selector spaces (both)", "[  href   ]", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
   t.deepEqual(tree.nodes[0].nodes[0].spaces.attribute.before, "  ");

--- a/src/parser.js
+++ b/src/parser.js
@@ -228,7 +228,7 @@ export default class Parser {
             }
             if (commentBefore) {
               ensureObject(node, "raws", "spaces", "attribute");
-              node.raws.spaces.attribute.before = spaceBefore;
+              node.raws.spaces.attribute.before = commentBefore;
               commentBefore = "";
             }
             node.namespace = (node.namespace || "") + content;


### PR DESCRIPTION
## Problem

Leading whitespace before a `*` (universal) namespace in an attribute selector is dropped on a round-trip, while it is preserved for a named namespace or no namespace:

```js
const parser = require("postcss-selector-parser");
const rt = (s) => { let o; parser((r) => (o = r.toString())).processSync(s); return o; };

rt("[ *|a ]");  // "[*|a ]"   ← leading space lost
rt("[ ns|a ]"); // "[ ns|a ]" (ok)
rt("[ |a ]");   // "[ |a ]"   (ok)
rt("[ a ]");    // "[ a ]"    (ok)
```

## Root cause

In `attribute()`, the `tokens.asterisk` branch records the raw spacing with the wrong variable:

```js
if (spaceBefore) {
  node.spaces.attribute.before = spaceBefore;
  spaceBefore = "";          // cleared here
}
if (commentBefore) {
  node.raws.spaces.attribute.before = spaceBefore;  // ← always "" now
  commentBefore = "";
}
```

`spaceBefore` has already been set to `""`, so `raws.spaces.attribute.before` is emptied. Since `toString` prefers the raw spacing when present, the leading whitespace disappears. The `tokens.word` branch right below does the same thing correctly with `commentBefore`.

## Fix

Use `commentBefore` for the raw spacing, matching the word-namespace branch (one word).

## Test plan

- Added an attribute test for a universal namespace with surrounding spaces (`[  *|bar   ]`); the tree was already correct, but the `toString` round-trip failed on `main` and passes with the fix.
- A round-trip property check over generated selectors flagged this case; the fix clears it with no regressions. Full suite green (779), `eslint`/`tsc` clean.
