### PR TITLE
fix(id): escape values assigned through the value setter

### DIFF
--- a/API.md
+++ b/API.md
@@ -68,6 +68,11 @@ Arguments:
 
 * `props (object)`: The new node's properties.
 
+Notes:
+* Assigning to `value` escapes characters that aren't valid in an identifier
+  (`node.value = 'foo.bar'` stringifies as `.foo\.bar`). To assign a
+  pre-escaped value, use `node.setPropertyWithoutEscape('value', v)` instead.
+
 ### `parser.combinator([props])`
 
 Creates a new selector combinator.
@@ -118,6 +123,12 @@ parser.id({value: 'search'});
 Arguments:
 
 * `props (object)`: The new node's properties.
+
+Notes:
+* Assigning to `value` escapes characters that aren't valid in an identifier
+  (`node.value = 'foo.bar'` stringifies as `#foo\.bar`), matching
+  `parser.className`. To assign a pre-escaped value, use
+  `node.setPropertyWithoutEscape('value', v)` instead.
 
 ### `parser.nesting([props])`
 

--- a/src/__tests__/id.mjs
+++ b/src/__tests__/id.mjs
@@ -5,6 +5,15 @@ test("id selector", "#one", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].type, "id");
 });
 
+test("ID#set value", "#fo\\o", (t, selectors) => {
+  let id = selectors.first.first;
+  t.deepEqual(id.raws, { value: "fo\\o" });
+  id.value = "bar";
+  t.deepEqual(id.raws, {});
+  id.value = "foo.bar";
+  t.deepEqual(id.raws, { value: "foo\\.bar" });
+});
+
 test("id selector with universal", "*#z98y ", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].value, "*");
   t.deepEqual(tree.nodes[0].nodes[0].type, "universal");

--- a/src/selectors/id.js
+++ b/src/selectors/id.js
@@ -1,3 +1,5 @@
+import cssesc from "cssesc";
+import { ensureObject } from "../util";
 import Node from "./node";
 import { ID as IDType } from "./types";
 
@@ -5,6 +7,24 @@ export default class ID extends Node {
   constructor(opts) {
     super(opts);
     this.type = IDType;
+    this._constructed = true;
+  }
+
+  set value(v) {
+    if (this._constructed) {
+      let escaped = cssesc(v, { isIdentifier: true });
+      if (escaped !== v) {
+        ensureObject(this, "raws");
+        this.raws.value = escaped;
+      } else if (this.raws) {
+        delete this.raws.value;
+      }
+    }
+    this._value = v;
+  }
+
+  get value() {
+    return this._value;
   }
 
   valueToString() {


### PR DESCRIPTION
﻿`ID` doesn't override `value`, so assigning to `id.value` stores the string as-is and `toString()` emits it unescaped. `ClassName` has had an escaping `value` setter since `d4dda8c5` ("Escape class name values by default", 2018), but `ID` never got the same one, even though class and id selectors are both identifiers and follow the same escaping rules.

The result is wrong output for any id value that contains characters needing escapes:

```js
const parser = require("postcss-selector-parser");

const cls = parser.className({ value: "x" });
cls.value = "foo.bar";
cls.toString(); // ".foo\\.bar"   (correct)

const id = parser.id({ value: "x" });
id.value = "foo.bar";
id.toString(); // "#foo.bar"   (wrong: re-parses to id "foo" + class "bar")
```

Leading digits, spaces and `#` break the same way: `#1abc`, `#a b`, `#a#b`.

This also fixes a second, worse symptom: on an ID that was *parsed* with an escape, reassigning `value` previously had **no effect at all**, because `raws.value` survived the assignment and `toString()` kept emitting the old escaped string:

```js
const id = parser().astSync('#fo\\o').first.first;
id.value = 'bar';
id.toString(); // main: '#fo\o'   branch: '#bar'
```

The new setter stores through `raws`, so stale `raws.value` is replaced on assignment (the test asserts `id.raws` goes back to `{}`).

This adds the same setter `ClassName` uses (`cssesc(v, { isIdentifier: true })` stored into `raws.value`), so id values escape on assignment:

```js
id.value = "foo.bar";
id.toString(); // "#foo\\.bar"
```

The new test mirrors the existing `ClassName#set value` test. `npm test` passes (lint, typecheck, full suite).
