### PR TITLE
Fix TypeError on unclosed `[`, `(` and trailing `|`

### DIFF
--- a/src/__tests__/exceptions.mjs
+++ b/src/__tests__/exceptions.mjs
@@ -7,6 +7,28 @@ throws("unclosed pseudo element", "button::");
 throws("unclosed pseudo class", "a:");
 throws("unclosed attribute selector", '[name="james"][href');
 
+// Constructs left open at end of input. These threw a raw TypeError before
+// `attribute`, `namespace` and `parentheses` guarded against running out of
+// tokens. Asserted by message rather than by type: the default
+// `{instanceOf: Error}` check is satisfied by a TypeError, which is why the
+// existing "unclosed attribute selector" case above passed throughout.
+throws(
+  "unclosed attribute at end of input",
+  "a[href",
+  "Expected a closing square bracket.",
+);
+throws(
+  "unclosed attribute with value at end of input",
+  "a[href=x",
+  "Expected a closing square bracket.",
+);
+throws("trailing namespace pipe", ".foo|", "Unexpected '|'.");
+throws(
+  "unclosed parenthesis at end of input",
+  "a(",
+  "Expected a closing parenthesis.",
+);
+
 throws("no opening parenthesis", ")");
 throws("no opening parenthesis (2)", ":global.foo)");
 throws("no opening parenthesis (3)", "h1:not(h2:not(h3)))");

--- a/src/parser.js
+++ b/src/parser.js
@@ -161,6 +161,11 @@ export default class Parser {
       attr.push(this.currToken);
       this.position++;
     }
+    if (!this.currToken) {
+      // Ran off the end of the token stream: the attribute was never closed.
+      // Point at the opening bracket, which is where the author needs to look.
+      return this.expected("closing square bracket", startingToken[TOKEN.START_POS]);
+    }
     if (this.currToken[TOKEN.TYPE] !== tokens.closeSquare) {
       return this.expected("closing square bracket", this.currToken[TOKEN.START_POS]);
     }
@@ -697,6 +702,11 @@ export default class Parser {
 
   namespace() {
     const before = (this.prevToken && this.content(this.prevToken)) || true;
+    if (!this.nextToken) {
+      // A trailing `|` with nothing after it. `unexpectedPipe` reports against
+      // `currToken`, which is the pipe itself and always present here.
+      return this.unexpectedPipe();
+    }
     if (this.nextToken[TOKEN.TYPE] === tokens.word) {
       this.position++;
       return this.word(before);
@@ -730,6 +740,7 @@ export default class Parser {
   parentheses() {
     let last = this.current.last;
     let unbalanced = 1;
+    const openingToken = this.currToken;
     this.position++;
     if (last && last.type === types.PSEUDO) {
       const selector = new Selector({
@@ -805,7 +816,12 @@ export default class Parser {
       }
     }
     if (unbalanced) {
-      return this.expected("closing parenthesis", this.currToken[TOKEN.START_POS]);
+      // `currToken` is undefined when the token stream ran out before the
+      // parenthesis was closed; fall back to the opening one.
+      return this.expected(
+        "closing parenthesis",
+        (this.currToken || openingToken)[TOKEN.START_POS],
+      );
     }
   }
 


### PR DESCRIPTION
Fixes #329.

Selectors that ran out of tokens before a bracket closed threw
`TypeError: Cannot read properties of undefined` instead of the parser's own
`Expected a closing …` error. The error path already existed in each case — it just couldn't be
reached, because constructing the message dereferenced the token that was missing.

| Input | Before | After |
|---|---|---|
| `a[href` | `TypeError: …reading '0'` | `Expected a closing square bracket.` |
| `a[href=x` | `TypeError: …reading '0'` | `Expected a closing square bracket.` |
| `a(` | `TypeError: …reading '5'` | `Expected a closing parenthesis.` |
| `.foo\|` | `TypeError: …reading '0'` | `Unexpected '\|'.` |

Closing delimiters with no opener (`a]`, `a)`) already produced clean errors, so this brings the
two directions into line.

## Changes

Three guards in `src/parser.js`:

- **`attribute()`** — the `while` loop exits on either a closing bracket or end of input, and the
  check after it assumed the former. Errors now point at the opening bracket, which is where the
  author needs to look.
- **`namespace()`** — a trailing `|` with nothing after it now goes to the existing
  `unexpectedPipe()`, which reports against `currToken` (the pipe itself, always present).
- **`parentheses()`** — the `unbalanced` branch falls back to the opening parenthesis when the
  stream ended.

No behaviour change for input that already parsed, and no change to any existing error message.

## Tests

Four cases added to `src/__tests__/exceptions.mjs`.

They assert the **message** rather than the type, deliberately. `src/__tests__/exceptions.mjs:8`
already covers this input shape:

```js
throws("unclosed attribute selector", '[name="james"][href');
```

That test passes today, because `throws` falls back to `{ instanceOf: Error }` when no message is
given (`util/helpers.mjs:33`) and `TypeError` satisfies it. Asserting the message is what makes
the new tests able to fail.

Confirmed they do: reverting only `src/parser.js` and re-running gives

```
actual:   "Cannot read properties of undefined (reading '5')"
expected: "Expected a closing parenthesis."
```

## Verification

- `npm test` — **781/781 pass** (777 before), `oxlint` clean, coverage thresholds met
- `npm run format:check` clean
- Verified against `postcss-selector-parser@7.1.4` from npm and against `main` at `4a7e4e3`

## Scope

I've limited this to the three paths I could reproduce. There are other unguarded token reads in
the file that may be unreachable in practice — I'd rather not add speculative guards to a parser
this widely used without a failing case to justify each one.
