### PR TITLE
fix: attribute selector with no valid attribute name

### DIFF
--- a/src/__tests__/attributes.mjs
+++ b/src/__tests__/attributes.mjs
@@ -1,4 +1,6 @@
 import { test, nodeVersionAtLeast, nodeVersionBefore } from "./util/helpers.mjs";
+import ava from "./util/runner.mjs";
+import parser from "../../dist/index.js";
 
 test("attribute selector", "[href]", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
@@ -556,3 +558,20 @@ testDeprecation("set Attribute#quoteMark", "[data-foo=bar]", (t, tree) => {
   attr.quoteMark = '"';
   t.deepEqual(attr.toString(), '[data-foo="has space"]');
 });
+
+// A trailing `* $ ^ ~ |` immediately before the closing bracket used to look
+// ahead past the end of the token stream and throw a raw TypeError. None of
+// them is a valid operator without a following `=`, so the token is dropped,
+// which matches how `[href=]` already drops an operator that has no value.
+// Asserted with `ava` rather than `test` because the output is intentionally
+// not a round-trip, and pinning it with `test` would assert the lossy form is
+// correct.
+for (const trailing of ["*", "$", "^", "~", "|"]) {
+  ava(`attribute name followed by a trailing ${trailing}`, (t) => {
+    const tree = parser().astSync(`[href${trailing}]`);
+    const attr = tree.nodes[0].nodes[0];
+    t.deepEqual(attr.attribute, "href");
+    t.deepEqual(attr.operator, undefined);
+    t.deepEqual(tree.toString(), "[href]");
+  });
+}

--- a/src/__tests__/exceptions.mjs
+++ b/src/__tests__/exceptions.mjs
@@ -29,6 +29,37 @@ throws(
   "Expected a closing parenthesis.",
 );
 
+// An attribute selector whose last token before `]` is one of `* $ ^ ~ |`.
+// The `attribute` token loop looked ahead to `next` without checking it
+// existed, so these threw a raw TypeError. Asserted by message for the same
+// reason as the cases above.
+throws(
+  "namespaced attribute name is an asterisk",
+  "[ns|*]",
+  "Expected an attribute.",
+);
+throws("default namespace with asterisk name", "[|*]", "Expected an attribute.");
+throws("any namespace with asterisk name", "[*|*]", "Expected an attribute.");
+throws(
+  "namespaced attribute ending in a dollar",
+  "[ns|$]",
+  "Expected an attribute.",
+);
+throws(
+  "namespaced attribute ending in a caret",
+  "[ns|^]",
+  "Expected an attribute.",
+);
+
+// A bracket pair that contains no attribute name at all. `toString` used to
+// interpolate the string "undefined" into the output.
+throws("universal selector as an attribute", "[ * ]", "Expected an attribute.");
+throws(
+  "asterisk name with trailing space",
+  "[ns|* ]",
+  "Expected an attribute.",
+);
+
 throws("no opening parenthesis", ")");
 throws("no opening parenthesis (2)", ":global.foo)");
 throws("no opening parenthesis (3)", "h1:not(h2:not(h3)))");

--- a/src/parser.js
+++ b/src/parser.js
@@ -219,7 +219,7 @@ export default class Parser {
           }
           break;
         case tokens.asterisk:
-          if (next[TOKEN.TYPE] === tokens.equals) {
+          if (next && next[TOKEN.TYPE] === tokens.equals) {
             node.operator = content;
             lastAdded = "operator";
           } else if (
@@ -256,14 +256,14 @@ export default class Parser {
           }
         // Falls through
         case tokens.caret:
-          if (next[TOKEN.TYPE] === tokens.equals) {
+          if (next && next[TOKEN.TYPE] === tokens.equals) {
             node.operator = content;
             lastAdded = "operator";
           }
           spaceAfterMeaningfulToken = false;
           break;
         case tokens.combinator:
-          if (content === "~" && next[TOKEN.TYPE] === tokens.equals) {
+          if (content === "~" && next && next[TOKEN.TYPE] === tokens.equals) {
             node.operator = content;
             lastAdded = "operator";
           }
@@ -271,7 +271,7 @@ export default class Parser {
             spaceAfterMeaningfulToken = false;
             break;
           }
-          if (next[TOKEN.TYPE] === tokens.equals) {
+          if (next && next[TOKEN.TYPE] === tokens.equals) {
             node.operator = content;
             lastAdded = "operator";
           } else if (!node.namespace && !node.attribute) {
@@ -414,6 +414,14 @@ export default class Parser {
           return this.error(`Unexpected "${content}" found.`, { index: token[TOKEN.START_POS] });
       }
       pos++;
+    }
+    if (!node.attribute) {
+      // Every token inside the brackets was consumed without one of them
+      // supplying an attribute name. Stringifying now would interpolate the
+      // string "undefined" into the output, so report it as a parse error
+      // instead. Points at the opening bracket, which is where the author
+      // needs to look.
+      return this.expected("attribute", startingToken[TOKEN.START_POS]);
     }
     unescapeProp(node, "attribute");
     unescapeProp(node, "namespace");


### PR DESCRIPTION
Fixes #334.

## The crash

`attribute()` read `next[TOKEN.TYPE]` in four places without checking that a next token existed:

- `case tokens.asterisk`
- `case tokens.caret` (also reached by `tokens.dollar` via fall-through)
- `case tokens.combinator`, the `~` check
- `case tokens.combinator`, the `|` check

So an attribute selector whose last token before `]` was `*`, `$`, `^`, `~` or `|` threw a raw `TypeError` out of the parser rather than the parser's own error. `[ns|*]`, `[a$]`, `[a|]` and eight other shapes were affected.

Two other reads of `next[TOKEN.TYPE]` in the same file already guard with `next &&`, and the `else if` directly below the asterisk case guards with `&& next`, so this follows the pattern already in the file rather than introducing one.

## Why the guards alone were not enough

Adding the four guards moved the failure instead of fixing it. With no attribute name captured, `Attribute#toString` interpolates the missing value, so `[ns|*]` became the string `[ns|undefined]`.

That path was already reachable without any crash. On 7.1.5:

```js
parser().astSync("[ * ]").toString();   // "[ *|undefined]"
```

`[*]` on its own already threw `Expected an attribute.`, so the two were inconsistent. The token loop now also rejects a bracket pair that supplied no attribute name, pointing at the opening bracket.

## Verification

Compared against pristine 7.1.5 across 43,200 generated attribute selectors, varying the name, namespace separator and its surrounding whitespace, operator, value, quoting, insensitivity flag, and padding:

| | 7.1.5 | this branch |
|---|---|---|
| raw `TypeError` | 341 | **0** |
| output containing the text `undefined` | 596 | **0** |
| output differs where both parsed | — | **0** |

The 596 that now raise `Expected an attribute.` are exactly the 596 that previously emitted `undefined`. No input that previously parsed produces different output.

`npm test` is green, including `oxlint`, the type check, and the coverage thresholds: 94.98% lines, 95.54% branches, 97.71% functions against gates of 94/94/96. Test count 789 to 801.

## Test placement

The newly-erroring cases are in `exceptions.mjs`, asserted **by message** rather than by type, for the reason recorded in that file in #330: the default `{instanceOf: Error}` check is satisfied by a `TypeError`, so a type-only assertion would not have caught this.

The five inputs that now parse instead of crashing (`[href*]`, `[href$]`, `[href^]`, `[href~]`, `[href|]`, each yielding `[href]`) are in `attributes.mjs` using `ava` directly rather than the `test` helper. `test` adds an automatic round-trip assertion, and these are deliberately not round-trips: the trailing token is dropped, matching how `[href=]` already drops an operator with no value. Using `test` would have asserted the lossy output is correct.

## Scope

`[ns | ]` still returns `[ns  ]` rather than treating `ns` as a namespace. That is the whitespace-before-`|` lookahead in #229 and is left alone here.

Preserving a trailing `*`/`$`/`^`/`~`/`|` so those five round-trip is also out of scope. It is the same lossy behaviour as `[href=]` and would be a separate change.