### PR TITLE
fix: `$` dropped from attribute names

### DIFF
--- a/src/__tests__/nonstandard.mjs
+++ b/src/__tests__/nonstandard.mjs
@@ -31,6 +31,41 @@ test("sass escapes (2)", "[lang=#{$locale}]", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].value, "#{$locale}");
 });
 
+test("sass interpolation as an attribute name", "[#{$attr}]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].type, "attribute");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "#{$attr}");
+  t.deepEqual(tree.nodes[0].nodes[0].operator, undefined);
+  t.deepEqual(tree.nodes[0].nodes[0].value, undefined);
+});
+
+test("sass variable as an attribute name", "[$attr]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "$attr");
+  t.deepEqual(tree.nodes[0].nodes[0].operator, undefined);
+});
+
+test(
+  "sass interpolation on both sides of an attribute selector",
+  "[#{$attr}=#{$value}]",
+  (t, tree) => {
+    t.deepEqual(tree.nodes[0].nodes[0].attribute, "#{$attr}");
+    t.deepEqual(tree.nodes[0].nodes[0].operator, "=");
+    t.deepEqual(tree.nodes[0].nodes[0].value, "#{$value}");
+  },
+);
+
+// The `$` opening the name must not be mistaken for the suffix match operator,
+// and the `$=` that follows must still parse as one.
+test("sass variable name with a suffix match operator", '[$attr$="x"]', (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "$attr");
+  t.deepEqual(tree.nodes[0].nodes[0].operator, "$=");
+  t.deepEqual(tree.nodes[0].nodes[0].value, "x");
+});
+
+test("namespaced sass variable attribute name", "[ns|$attr]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "ns");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "$attr");
+});
+
 test("placeholder", "%foo", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].type, "tag");
   t.deepEqual(tree.nodes[0].nodes[0].value, "%foo");

--- a/src/parser.js
+++ b/src/parser.js
@@ -254,6 +254,22 @@ export default class Parser {
             }
             break;
           }
+          if (
+            (lastAdded === "attribute" || !node.attribute) &&
+            !(next && next[TOKEN.TYPE] === tokens.equals)
+          ) {
+            // A `$` that is not followed by `=` is part of the attribute name
+            // rather than the suffix match operator. Preprocessors emit these
+            // through interpolation, e.g. `[#{$var}]` in SCSS.
+            let oldRawAttribute = getProp(node, "raws", "attribute");
+            node.attribute = (node.attribute || "") + "$";
+            if (oldRawAttribute) {
+              node.raws.attribute = oldRawAttribute + "$";
+            }
+            lastAdded = "attribute";
+            spaceAfterMeaningfulToken = false;
+            break;
+          }
         // Falls through
         case tokens.caret:
           if (next[TOKEN.TYPE] === tokens.equals) {


### PR DESCRIPTION
Fixes #211. Fixes #306.

Both reports are the same defect seen through different syntax.

## The bug

```js
parser().astSync("[#{$attr}]").toString();   // "[#{attr}]"
parser().astSync("[$attr]").toString();      // "[attr]"
parser().astSync("[#{$a}=#{$b}]").toString() // "[#{a}=#{$b}]"
```

The `$` is dropped when it belongs to the attribute name. The value position already worked, which is why `[lang=#{$locale}]` round-trips in the existing tests while `[#{$attr}]` does not.

## Cause

`attribute()` has a branch for `$` in the value position, and the `tokens.caret` case immediately below turns `$` into the suffix match operator when the next token is `=`. Nothing handled a `$` that is part of the attribute name, so it fell through to `tokens.caret`, failed the `=` check, and was discarded without being recorded anywhere.

The new branch mirrors the value-position handling, and is guarded on the next token not being `=`.

## Why the guard matters

Without it, `$=` stops parsing as an operator. With it, a name and an operator can coexist:

```js
parser().astSync('[$attr$="x"]')
// attribute "$attr", operator "$=", value "x"
```

`[a$=x]` and `[data-weird-attr$="Something=weird"]` are unaffected, and both remain covered by the existing tests.

## Verification

Compared against `main` across 4,800 generated attribute selectors, varying the name, namespace, operator, value, quoting, insensitivity flag and padding:

| | |
|---|---|
| newly round-tripping | **991** |
| regressions (round-tripped before, broken now) | **0** |
| parsed before, throws now | **0** |
| raw `TypeError` | 45 → 30 |

The `TypeError` reduction is a side effect rather than the aim: a trailing `$` such as `[a$]` now returns before reaching the unguarded `next[TOKEN.TYPE]` lookahead in `tokens.caret`. That lookahead is the subject of #334 and is not otherwise touched here.

`npm test` passes, including `oxlint`, the type check and the coverage thresholds: 94.99% lines, 95.41% branches, 97.71% functions against gates of 94/94/96. Test count 789 to 799.

## Tests

Added to `nonstandard.mjs`, next to the existing `sass escapes` cases, since these arrive through preprocessor interpolation: interpolated attribute name, bare `$` name, interpolation on both sides, a `$` name combined with `$=`, and a namespaced `$` name.

## Not addressed

`[#{$attr} i]` still drops the insensitivity flag, both before and after this change. The flag survives only when an operator is present, which is a separate defect and left alone.
