### PR TITLE
fix: lossless mode drops whitespace when a selector ends empty

### DIFF
--- a/src/__tests__/pseudos.mjs
+++ b/src/__tests__/pseudos.mjs
@@ -184,3 +184,20 @@ test("nested pseudo classes", "section:not( :has(h1, h2 ) )", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[1].nodes[0].nodes[0].nodes[1].nodes[0].type, "tag");
   t.deepEqual(tree.nodes[0].nodes[1].nodes[0].nodes[0].nodes[1].nodes[0].value, "h2");
 });
+
+// Whitespace is stored on nodes, so a selector that ends before any node is
+// created had nowhere to keep it and lost it. `test` asserts the round-trip.
+test("trailing space after a comma inside a pseudo", ":not(a, )", (t, tree) => {
+  const args = tree.nodes[0].nodes[0].nodes;
+  t.deepEqual(args.length, 2);
+  t.deepEqual(args[1].toString(), " ");
+});
+
+test("trailing space in a nested pseudo", "div:has(a, )");
+test("trailing space after several commas", ":not(a, b, )");
+test("space before a trailing comma", ":not(a , )");
+test("whitespace-only pseudo argument", ":not( )");
+test("multiple spaces in a whitespace-only argument", ":not(  )");
+test("trailing space after a top-level comma", "a, ");
+test("space around a comment in a pseudo argument", ":not( /*c*/ )");
+

--- a/src/parser.js
+++ b/src/parser.js
@@ -641,7 +641,37 @@ export default class Parser {
     return this.newNode(node);
   }
 
+  // Whitespace is only ever stored on a node, as `spaces.before` or
+  // `spaces.after`. `space()` parks leading whitespace on `this.spaces` for the
+  // next node to claim, so a selector that ends before any node is created --
+  // `:not(a, )`, `:not( )`, a trailing `a, ` -- drops it. Park it on an empty
+  // string node instead, which is what `parseWhitespaceEquivalentTokens`
+  // already does for the comment-adjacent case.
+  flushPendingSpaces() {
+    if (!this.spaces) {
+      return;
+    }
+    const last = this.current.last;
+    if (last) {
+      // `space()` routes trailing whitespace to `this.spaces` whenever the
+      // selector so far holds nothing but comments, so `:not( /*c*/ )` lands
+      // here rather than on the `spaces.after` path.
+      last.spaces.after += this.spaces;
+      this.spaces = "";
+      return;
+    }
+    const token = this.currToken || this.prevToken;
+    this.newNode(
+      new Str({
+        value: "",
+        source: token ? getTokenSource(token) : undefined,
+        sourceIndex: token ? token[TOKEN.START_POS] : 0,
+      }),
+    );
+  }
+
   comma() {
+    this.flushPendingSpaces();
     if (this.position === this.tokens.length - 1) {
       this.root.trailingComma = true;
       this.position++;
@@ -782,6 +812,7 @@ export default class Parser {
           if (unbalanced) {
             this.parse();
           } else {
+            this.flushPendingSpaces();
             this.current.source.end = tokenEnd(this.currToken);
             this.current.parent.source.end = tokenEnd(this.currToken);
             this.position++;
@@ -1005,6 +1036,7 @@ export default class Parser {
     while (this.position < this.tokens.length) {
       this.parse(true);
     }
+    this.flushPendingSpaces();
     this.current._inferEndPosition();
     return this.root;
   }


### PR DESCRIPTION
Fixes #298. @alexander-akait said "pr welcome" on the issue.

## The cause

`space()` parks leading whitespace on `this.spaces` for the next node to claim, and `newNode` is its only consumer:

```js
if (this.spaces) {
  node.spaces.before = this.spaces;
  this.spaces = "";
}
```

Whitespace in this parser only exists as a property of a node. A selector that ends before any node is created has nowhere to keep it, so it is silently dropped. That is why `:not( a )` round-trips — the space attaches to the tag — while `:not(a, )` does not.

Two conditions in `space()` route whitespace onto `this.spaces`: the previous token is a comma or an opening parenthesis, **or** the selector so far holds nothing but comments. The second is why `:not( /*c*/ )` loses its trailing space too.

## Scope

The issue reports `:not(a, )`. The same defect covers more than that, including a case with no pseudo involved:

| input | before | after |
|---|---|---|
| `:not(a, )` | `:not(a,)` | `:not(a, )` |
| `:not(a, b, )` | `:not(a, b,)` | `:not(a, b, )` |
| `:not(a , )` | `:not(a ,)` | `:not(a , )` |
| `div:has(a, )` | `div:has(a,)` | `div:has(a, )` |
| `:not( )` | `:not()` | `:not( )` |
| `:not(  )` | `:not()` | `:not(  )` |
| `:not( /*c*/ )` | `:not( /*c*/)` | `:not( /*c*/ )` |
| `a, ` | `a,` | `a, ` |

## The change

Pending whitespace is flushed at the three points where a selector can close: at a comma, at a pseudo's closing parenthesis, and at end of input.

It attaches to the last node's `spaces.after` when there is one, and otherwise to an empty `Str` node — which is what `parseWhitespaceEquivalentTokens` already does for the comment-adjacent case, so the AST shape is not a new idea.

## Verification

Across 480 generated selectors — six pseudo forms × sixteen argument shapes × five enclosing contexts:

| | |
|---|---|
| newly round-tripping | **240** |
| regressions | **0** |
| `lossless: false` output vs `main` | **byte-identical** |

Lossy mode is deliberately untouched: `:not(a, )` still minifies to `:not(a,)`.

`npm test` passes, including `oxlint`, the type check and the coverage thresholds: 95.02% lines, 95.30% branches, 97.72% functions against gates of 94/94/96. Test count 789 to 798.

## Tests

Nine cases in `pseudos.mjs`, which uses the `test` helper and so asserts the round-trip automatically. **With the fix reverted but the tests kept, all nine fail** — they do not pass incidentally.

## A note on the AST

`:not( )` now yields a selector containing one empty `Str` node rather than an empty selector. Anything iterating `.nodes` will see it. The alternative was to store the whitespace on the `Selector` itself and teach `Container._stringify` to emit it, which keeps the AST cleaner but changes serialisation for every container type. I took the lower-risk option, but happy to switch if you would rather have the other.
