### PR TITLE
fix: keep whitespace around the namespace separator in attribute selectors

### DIFF
--- a/src/__tests__/lossy.mjs
+++ b/src/__tests__/lossy.mjs
@@ -28,6 +28,12 @@ ava("attribute, insensitive flag 2", testLossy, "[href=TEsT i  ]", "[href=TEsT i
 ava("attribute, insensitive flag 3", testLossy, "[href=test i  ]", "[href=test i]");
 ava("attribute, extreneous whitespace", testLossy, "  [href]   ,  [class]   ", "[href],[class]");
 
+ava("attribute namespace, space before separator", testLossy, "[foo |bar]", "[foo|bar]");
+ava("attribute namespace, space after separator", testLossy, "[foo| bar]", "[foo|bar]");
+ava("attribute namespace, spaces around separator", testLossy, "[ foo | bar ]", "[foo|bar]");
+ava("any attribute namespace, spaces around separator", testLossy, "[ * | href ]", "[*|href]");
+ava("empty attribute namespace, space after separator", testLossy, "[ | href ]", "[|href]");
+
 ava("namespace, space before", testLossy, "   postcss|button", "postcss|button");
 ava("namespace, space after", testLossy, "postcss|button     ", "postcss|button");
 ava("namespace - all elements, space before", testLossy, "   postcss|*", "postcss|*");

--- a/src/__tests__/namespaces.mjs
+++ b/src/__tests__/namespaces.mjs
@@ -60,6 +60,106 @@ test("match default namespace inside attribute selector with spaces", "[ |href ]
   t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
 });
 
+test("attribute namespace with a space before the separator", "[foo |bar]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "foo");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "bar");
+});
+
+test("attribute namespace with a space after the separator", "[foo| bar]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "foo");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "bar");
+});
+
+test("attribute namespace with spaces around the separator", "[ foo | bar ]", (t, tree) => {
+  const attr = tree.nodes[0].nodes[0];
+  t.deepEqual(attr.namespace, "foo");
+  t.deepEqual(attr.attribute, "bar");
+  t.deepEqual(attr.spaces.attribute.before, " ");
+  t.deepEqual(attr.spaces.attribute.after, " ");
+});
+
+test(
+  "attribute namespace with multiple spaces around the separator",
+  "[  foo  |  bar  ]",
+  (t, tree) => {
+    const attr = tree.nodes[0].nodes[0];
+    t.deepEqual(attr.namespace, "foo");
+    t.deepEqual(attr.attribute, "bar");
+    t.deepEqual(attr.spaces.attribute.before, "  ");
+    t.deepEqual(attr.spaces.attribute.after, "  ");
+  },
+);
+
+test(
+  "attribute namespace with spaces around the separator and a value",
+  "[ foo | bar = baz ]",
+  (t, tree) => {
+    const attr = tree.nodes[0].nodes[0];
+    t.deepEqual(attr.namespace, "foo");
+    t.deepEqual(attr.attribute, "bar");
+    t.deepEqual(attr.operator, "=");
+    t.deepEqual(attr.value, "baz");
+  },
+);
+
+test(
+  "attribute namespace with spaces around the separator and a quoted value",
+  '[ foo | bar = "baz" i ]',
+  (t, tree) => {
+    const attr = tree.nodes[0].nodes[0];
+    t.deepEqual(attr.namespace, "foo");
+    t.deepEqual(attr.attribute, "bar");
+    t.deepEqual(attr.value, "baz");
+    t.deepEqual(attr.insensitive, true);
+  },
+);
+
+test("empty attribute namespace with a space after the separator", "[ | href ]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, true);
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
+});
+
+test("empty attribute namespace with a space after the separator only", "[| href]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, true);
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
+});
+
+test("any attribute namespace with a space before the separator", "[* |href]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "*");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
+});
+
+test("any attribute namespace with spaces around the separator", "[ * | href ]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "*");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "href");
+});
+
+test("escaped attribute namespace with a space before the separator", "[f\\oo |bar]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "foo");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "bar");
+});
+
+test("escaped attribute name with a space after the separator", "[foo| b\\or]", (t, tree) => {
+  t.deepEqual(tree.nodes[0].nodes[0].namespace, "foo");
+  t.deepEqual(tree.nodes[0].nodes[0].attribute, "bor");
+});
+
+test("dash match operator is not an attribute namespace separator", "[ href |= en ]", (t, tree) => {
+  const attr = tree.nodes[0].nodes[0];
+  t.deepEqual(attr.namespace, undefined);
+  t.deepEqual(attr.attribute, "href");
+  t.deepEqual(attr.operator, "|=");
+  t.deepEqual(attr.value, "en");
+});
+
+test("dash match operator after an attribute namespace", "[ a | b |= c ]", (t, tree) => {
+  const attr = tree.nodes[0].nodes[0];
+  t.deepEqual(attr.namespace, "a");
+  t.deepEqual(attr.attribute, "b");
+  t.deepEqual(attr.operator, "|=");
+  t.deepEqual(attr.value, "c");
+});
+
 test("namespace with qualified id selector", "ns|h1#foo", (t, tree) => {
   t.deepEqual(tree.nodes[0].nodes[0].namespace, "ns");
 });
@@ -91,6 +191,9 @@ test("empty namespace after a combinator is not a prefix", ".a > |b", (t, tree) 
   t.deepEqual(tree.nodes[0].nodes[2].namespace, true);
   t.deepEqual(tree.nodes[0].nodes[2].value, "b");
 });
+
+throws("attribute namespace with no attribute name", "[foo |*=en]");
+throws("attribute namespace with an empty attribute name", "[foo | =en]");
 
 throws("lone pipe symbol", "|");
 throws("lone pipe symbol with leading spaces", " |");

--- a/src/parser.js
+++ b/src/parser.js
@@ -150,6 +150,24 @@ export default class Parser {
     };
   }
 
+  namespaceSeparatorFollows(attr, pos) {
+    let next = pos;
+    while (attr[next] && attr[next][TOKEN.TYPE] === tokens.space) {
+      next++;
+    }
+    if (!attr[next] || this.content(attr[next]) !== "|") {
+      return false;
+    }
+    next++;
+    if (attr[next] && attr[next][TOKEN.TYPE] === tokens.equals) {
+      return false;
+    }
+    while (attr[next] && attr[next][TOKEN.TYPE] === tokens.space) {
+      next++;
+    }
+    return Boolean(attr[next]);
+  }
+
   attribute() {
     const attr = [];
     const startingToken = this.currToken;
@@ -185,6 +203,7 @@ export default class Parser {
     let commentBefore = "";
     let lastAdded = null;
     let spaceAfterMeaningfulToken = false;
+    let namespaceSpaces = null;
 
     while (pos < len) {
       const token = attr[pos];
@@ -201,6 +220,15 @@ export default class Parser {
           // }
           spaceAfterMeaningfulToken = true;
           if (this.options.lossy) {
+            break;
+          }
+          if (namespaceSpaces !== null) {
+            namespaceSpaces += content;
+            break;
+          }
+          if (lastAdded === "namespace") {
+            ensureObject(node, "raws");
+            node.raws.namespace = (node.raws.namespace || node.namespace) + content;
             break;
           }
           if (lastAdded) {
@@ -226,6 +254,11 @@ export default class Parser {
             (!node.namespace || (lastAdded === "namespace" && !spaceAfterMeaningfulToken)) &&
             next
           ) {
+            node.namespace = (node.namespace || "") + content;
+            const rawValue = getProp(node, "raws", "namespace") || null;
+            if (rawValue) {
+              node.raws.namespace += content;
+            }
             if (spaceBefore) {
               ensureObject(node, "spaces", "attribute");
               node.spaces.attribute.before = spaceBefore;
@@ -235,11 +268,6 @@ export default class Parser {
               ensureObject(node, "raws", "spaces", "attribute");
               node.raws.spaces.attribute.before = commentBefore;
               commentBefore = "";
-            }
-            node.namespace = (node.namespace || "") + content;
-            const rawValue = getProp(node, "raws", "namespace") || null;
-            if (rawValue) {
-              node.raws.namespace += content;
             }
             lastAdded = "namespace";
           }
@@ -274,20 +302,16 @@ export default class Parser {
           if (next[TOKEN.TYPE] === tokens.equals) {
             node.operator = content;
             lastAdded = "operator";
-          } else if (!node.namespace && !node.attribute) {
-            node.namespace = true;
+          } else if (!node.operator) {
+            if (!node.namespace && !node.attribute) {
+              node.namespace = true;
+            }
+            namespaceSpaces = "";
           }
           spaceAfterMeaningfulToken = false;
           break;
         case tokens.word:
-          if (
-            next &&
-            this.content(next) === "|" &&
-            attr[pos + 2] &&
-            attr[pos + 2][TOKEN.TYPE] !== tokens.equals && // this look-ahead probably fails with comment nodes involved.
-            !node.operator &&
-            !node.namespace
-          ) {
+          if (this.namespaceSeparatorFollows(attr, pos + 1) && !node.operator && !node.namespace) {
             node.namespace = content;
             lastAdded = "namespace";
           } else if (!node.attribute || (lastAdded === "attribute" && !spaceAfterMeaningfulToken)) {
@@ -302,6 +326,11 @@ export default class Parser {
               node.raws.spaces.attribute.before = commentBefore;
               commentBefore = "";
             }
+            if (namespaceSpaces) {
+              ensureObject(node, "raws");
+              node.raws.attribute = namespaceSpaces + (node.raws.attribute || node.attribute || "");
+            }
+            namespaceSpaces = null;
             node.attribute = (node.attribute || "") + content;
             const rawValue = getProp(node, "raws", "attribute") || null;
             if (rawValue) {


### PR DESCRIPTION
Fixes #229.

`[ foo | bar ]` stringified as `[ foo  ]` and `[foo |bar]` as `[foobar ]`. The namespace lookahead in `attribute()` required `|` to be the immediately next token, so with whitespace the prefix was never recognised, the `|` was dropped, and the attribute name was discarded or fused onto it.

The lookahead now skips space tokens, and the whitespace on either side of the separator is kept in `raws.namespace` / `raws.attribute`, where `qualifiedAttribute` reads it back from. No stringifier or API change.

One deliberate behaviour change: a namespace with no attribute name, such as `[foo |*=en]`, now raises the parser's own `Expected an attribute` error instead of stringifying to mangled output.